### PR TITLE
Prune Cache

### DIFF
--- a/Sources/PlayolaPlayer/Player/FileDownloader.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloader.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 @Observable
 public final class FileDownloader: NSObject, @unchecked Sendable {
-  public static let subfolderName = "AudioFiles"
   var remoteUrl: URL!
   var localUrl: URL!
   var handleProgressBlock: ((Float) -> Void)?
@@ -25,7 +24,6 @@ public final class FileDownloader: NSObject, @unchecked Sendable {
               onProgress: ((Float) -> Void)?,
               onCompletion: ((FileDownloader) -> Void)?) {
     super.init()
-    print("SELF: \(self)")
     self.remoteUrl = remoteUrl
     self.localUrl = localUrl
     self.handleProgressBlock = onProgress
@@ -51,7 +49,6 @@ extension FileDownloader: URLSessionDownloadDelegate {
   public func urlSession(_ session: URLSession,
                          downloadTask: URLSessionDownloadTask,
                          didFinishDownloadingTo location: URL) {
-    print("Here it is \(self)")
     let manager = FileManager()
     guard !manager.fileExists(atPath: localUrl.path) else {
       print("file exists already at \(localUrl.path)")

--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -38,10 +38,15 @@ open class PlayolaMainMixer: NSObject {
         self.mixerNode = AVAudioMixerNode()
         self.engine = AVAudioEngine()
         self.engine.attach(self.mixerNode)
-        self.engine.connect(self.mixerNode, to: self.engine.mainMixerNode, format: TapProperties.default.format)
+        self.engine.connect(self.mixerNode,
+                            to: self.engine.mainMixerNode,
+                            format: TapProperties.default.format)
         self.engine.prepare()
 
-        self.mixerNode.installTap(onBus: 0, bufferSize: TapProperties.default.bufferSize, format: TapProperties.default.format, block: self.onTap(_:_:))
+        self.mixerNode.installTap(onBus: 0,
+                                  bufferSize: TapProperties.default.bufferSize,
+                                  format: TapProperties.default.format,
+                                  block: self.onTap(_:_:))
     }
 
     deinit {

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -11,6 +11,7 @@ import AVFAudio
 
 let baseUrl = URL(string: "https://admin-api.playola.fm/v1")!
 
+
 @MainActor
 @Observable
 final public class PlayolaStationPlayer: Sendable {
@@ -33,7 +34,9 @@ final public class PlayolaStationPlayer: Sendable {
     self.fileDownloadManager = FileDownloadManager()
   }
 
-  private static let logger = OSLog(subsystem: "PlayolaPlayer", category: "PlayolaPlayer")
+  private static let logger = OSLog(
+    subsystem: "PlayolaPlayer",
+    category: "PlayolaStationPlayer")
 
   private func getAvailableSpinPlayer() -> SpinPlayer {
     let availablePlayers = spinPlayers.filter({ $0.state == .available })
@@ -116,6 +119,11 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
     Task {
       do {
         await self.scheduleUpcomingSpins()
+        self.fileDownloadManager.pruneCache(
+          excludeFilepaths: self.spinPlayers
+            .filter{ $0.localUrl != nil }
+            .map { $0.localUrl!.path }
+        )
       } catch let error {
         print(error)
       }
@@ -131,4 +139,3 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
     print("new state: \(state)")
   }
 }
-

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -85,8 +85,11 @@ public class SpinPlayer {
 
     do {
       let session = AVAudioSession()
-      try
-      session.setCategory(AVAudioSession.Category(rawValue: convertFromAVAudioSessionCategory(AVAudioSession.Category.playAndRecord)), mode: AVAudioSession.Mode.default, options: [
+      try session.setCategory(
+        AVAudioSession.Category(
+          rawValue: AVAudioSession.Category.playAndRecord.rawValue),
+        mode: AVAudioSession.Mode.default,
+        options: [
         .allowBluetoothA2DP,
         .defaultToSpeaker
       ])
@@ -283,9 +286,4 @@ public class SpinPlayer {
     })
     RunLoop.main.add(self.clearTimer!, forMode: .default)
   }
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-private func convertFromAVAudioSessionCategory(_ input: AVAudioSession.Category) -> String {
-  return input.rawValue
 }

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -19,6 +19,8 @@ public class SpinPlayer {
   public var startNotificationTimer: Timer?
   public var clearTimer: Timer?
 
+  public var localUrl: URL? { return currentFile?.url }
+
   // dependencies
   @objc var playolaMainMixer: PlayolaMainMixer = .shared
   private var fileDownloadManager: FileDownloadManager!
@@ -234,7 +236,7 @@ public class SpinPlayer {
   /// Loads an audio file at the provided URL into the player node
   public func loadFile(with url: URL) {
     os_log("%@ - %d", log: SpinPlayer.logger, type: .default, #function, #line)
-    
+
     do {
       currentFile = try AVAudioFile(forReading: url)
     } catch {

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -15,21 +15,7 @@ public class SpinPlayer {
   public var duration: Double = 0
   public var spin: Spin? {
     didSet {
-      if spin == nil {
-        self.clearTimer?.invalidate()
-      } else if let endtime = spin?.endtime {
-        // for now, fire a
-        self.clearTimer = Timer(fire: endtime.addingTimeInterval(1),
-                                      interval: 0,
-                                      repeats: false, block: { timer in
-          DispatchQueue.main.async {
-            self.stop()
-            self.clear()
-          }
-          timer.invalidate()
-        })
-        RunLoop.main.add(self.clearTimer!, forMode: .default)
-      }
+      setClearTimer(spin)
     }
   }
 
@@ -277,6 +263,25 @@ public class SpinPlayer {
     
     let currentTime = TimeInterval(playerTime.sampleTime) / playerTime.sampleRate
     delegate?.player(self, didPlayFile: file, atTime: currentTime, withBuffer: buffer)
+  }
+
+  private func setClearTimer(_ spin: Spin?) {
+    guard let endtime = spin?.endtime else {
+      self.clearTimer?.invalidate()
+      return
+    }
+
+    // for now, fire a
+    self.clearTimer = Timer(fire: endtime.addingTimeInterval(1),
+                                  interval: 0,
+                                  repeats: false, block: { timer in
+      DispatchQueue.main.async {
+        self.stop()
+        self.clear()
+      }
+      timer.invalidate()
+    })
+    RunLoop.main.add(self.clearTimer!, forMode: .default)
   }
 }
 


### PR DESCRIPTION
This pull request introduces several changes to the `PlayolaPlayer` module, focusing on cache management, code cleanup, and improvements to the `SpinPlayer` class. The most significant changes include the addition of cache management functions, the removal of unnecessary print statements, and the refactoring of the `SpinPlayer` class for better readability and functionality.

### Cache Management:
* Added a `calculateFolderCacheSize` method and a `pruneCache` method to the `FileDownloadManager` class to handle file cache size and pruning of old files. [[1]](diffhunk://#diff-9dfd18d54d1430da4d041b4e68e150a5ee00bbd389292a09b99e21171d3d918fR70-R133) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR122-R126)

### Code Cleanup:
* Removed unnecessary print statements from the `FileDownloader` class. [[1]](diffhunk://#diff-a13934af3d9bb9217ff7fe6435caa0734700fb546ff472c114ced3397ada4e0cL28) [[2]](diffhunk://#diff-a13934af3d9bb9217ff7fe6435caa0734700fb546ff472c114ced3397ada4e0cL54)
* Changed the logger category in `PlayolaStationPlayer` for better specificity.

### SpinPlayer Improvements:
* Refactored the `SpinPlayer` class to include a `setClearTimer` method and moved the duration calculation to a computed property. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L15-L57) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L240-R282)
* Improved the readability of the `SpinPlayer` class by reformatting method calls and removing redundant code. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L102-R94) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L113-R106)

### Miscellaneous:
* Added a constant `MAX_AUDIO_FOLDER_SIZE` to the `FileDownloadManager` class.
* Adjusted the formatting in several files for consistency and readability. [[1]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL41-R49) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL134)