### PR TITLE
Volume Normalization for Spin Player

### DIFF
--- a/Sources/PlayolaPlayer/Player/AudioNormalizationCalculator.swift
+++ b/Sources/PlayolaPlayer/Player/AudioNormalizationCalculator.swift
@@ -1,0 +1,54 @@
+//
+//  AudioNormalizationCalculator.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 2/7/25.
+//
+import AVFoundation
+
+struct AudioNormalizationCalculator {
+    enum AudioError: Error {
+        case fileConversion
+        case bufferConversion
+    }
+
+  let file: AVAudioFile
+  var amplitude: Float? = nil
+
+  public func adjustedVolume(_ playerVolume: Float) -> Float {
+    guard let amplitude else { return 1.0 }
+    return playerVolume / amplitude
+  }
+
+  public func playerVolume(_ adjustedVolume: Float) -> Float {
+    return (amplitude ?? 1.0) * adjustedVolume
+  }
+
+  init(_ file: AVAudioFile) {
+    self.file = file
+    do {
+      let samples = try getSamples()
+      self.amplitude = getAmplitude(samples)
+    } catch {
+      print("Error getting samples")
+    }
+  }
+
+  func getSamples() throws -> [Float] {
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: AVAudioFrameCount(file.length)) else {
+            throw AudioError.bufferConversion
+        }
+        do {
+            try file.read(into: buffer)
+        } catch {
+            throw error
+        }
+        let floatArray = Array(UnsafeBufferPointer(start: buffer.floatChannelData?.pointee, count:Int(buffer.frameLength)))
+        return floatArray
+    }
+
+  func getAmplitude(_ samples: [Float]) -> Float? {
+    let absArray = samples.map { abs($0) }
+    return absArray.max()
+  }
+}

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -50,10 +50,12 @@ public class SpinPlayer {
 
   /// An internal instance of AVAudioEngine
   private let engine: AVAudioEngine! = PlayolaMainMixer.shared.engine!
-  
+
   /// The node responsible for playing the audio file
   private let playerNode = AVAudioPlayerNode()
-  
+
+  private var normalizationCalculator: AudioNormalizationCalculator?
+
   /// The currently playing audio file
   private var currentFile: AVAudioFile? {
     didSet {
@@ -63,25 +65,34 @@ public class SpinPlayer {
     }
   }
 
+
+
   /// A Bool indicating whether the engine is playing or not
   public var isPlaying: Bool {
     return playerNode.isPlaying
   }
-  
+
   public var volume: Float {
     get {
-      return playerNode.volume
+      guard let normalizationCalculator else { return playerNode.volume }
+      return normalizationCalculator.playerVolume(playerNode.volume)
     }
     set {
-      playerNode.volume = newValue
+      guard let normalizationCalculator else {
+        playerNode.volume = newValue
+        return
+      }
+      print("Original volume: \(newValue)")
+      print("Normalized Volume: \(normalizationCalculator.adjustedVolume(newValue))")
+      playerNode.volume = normalizationCalculator.adjustedVolume(newValue)
     }
   }
-  
+
   /// Singleton instance of the player
   static let shared = SpinPlayer()
-  
+
   // MARK: Lifecycle
-  
+
   init(delegate: SpinPlayerDelegate? = nil,
        fileDownloadManager: FileDownloadManager? = nil) {
     self.fileDownloadManager = fileDownloadManager ?? .shared
@@ -94,27 +105,27 @@ public class SpinPlayer {
           rawValue: AVAudioSession.Category.playback.rawValue),
         mode: AVAudioSession.Mode.default,
         options: [
-        .allowBluetoothA2DP,
-        .defaultToSpeaker,
-        .allowAirPlay,
-      ])
+          .allowBluetoothA2DP,
+          .defaultToSpeaker,
+          .allowAirPlay,
+        ])
     } catch {
       os_log("Error setting up session: %@", log: SpinPlayer.logger, type: .default, #function, #line, error.localizedDescription)
     }
-  
+
     /// Make connections
     engine.attach(playerNode)
     engine.connect(playerNode,
                    to: playolaMainMixer.mixerNode,
                    format: TapProperties.default.format)
     engine.prepare()
-    
+
     /// Install tap
     //        playerNode.installTap(onBus: 0, bufferSize: TapProperties.default.bufferSize, format: TapProperties.default.format, block: onTap(_:_:))
   }
-  
+
   // MARK: Playback
-  
+
   public func stop() {
     stopAudio()
     clear()
@@ -145,14 +156,14 @@ public class SpinPlayer {
   private func playNow(from: Double, to: Double? = nil) {
     do {
       try engine.start()
-      
+
       // calculate segment info
       let sampleRate = playerNode.outputFormat(forBus: 0).sampleRate
       let newSampleTime = AVAudioFramePosition(sampleRate * from)
       let framesToPlay = AVAudioFrameCount(Float(sampleRate) * Float(duration))
-      
+
       // stop the player, schedule the segment, restart the player
-      playerNode.volume = 1.0
+      self.volume = 1.0
       playerNode.stop()
       playerNode.scheduleSegment(currentFile!, startingFrame: newSampleTime, frameCount: framesToPlay, at: nil, completionHandler: nil)
       playerNode.play()
@@ -168,7 +179,7 @@ public class SpinPlayer {
              error.localizedDescription)
     }
   }
-  
+
   public func scheduleFade(at: Date, startingVolume: Float, endingVolume: Float) {
   }
 
@@ -188,6 +199,7 @@ public class SpinPlayer {
       } else {
         self.schedulePlay(at: spin.airtime)
       }
+      self.volume = 1.0
       self.state = .loaded
     }
   }
@@ -198,7 +210,7 @@ public class SpinPlayer {
     let secsUntilDate = date.timeIntervalSinceNow
     return AVAudioTime(sampleTime: now + Int64(secsUntilDate * outputFormat.sampleRate), atRate: outputFormat.sampleRate)
   }
-  
+
   /// schedule a future play from the beginning of the file
   public func schedulePlay(at: Date) {
     do {
@@ -206,7 +218,7 @@ public class SpinPlayer {
       let avAudiotime = avAudioTimeFromDate(date: at)
       playerNode.play(at: avAudiotime)
 
-      // for now, fire a 
+      // for now, fire a
       self.startNotificationTimer = Timer(fire: at,
                                           interval: 0,
                                           repeats: false, block: { timer in
@@ -222,22 +234,22 @@ public class SpinPlayer {
       os_log("Error starting engine: %@", log: SpinPlayer.logger, type: .default, #function, #line, error.localizedDescription)
     }
   }
-  
+
   /// Pauses playback (pauses the engine and player node)
   func pause() {
     os_log("%@ - %d", log: SpinPlayer.logger, type: .default, #function, #line)
-    
+
     guard isPlaying, let _ = currentFile else {
       return
     }
-    
+
     playerNode.pause()
     engine.pause()
-//    delegate?.player(self, didChangePlaybackState: false)
+    //    delegate?.player(self, didChangePlaybackState: false)
   }
-  
+
   // MARK: File Loading
-  
+
   /// Loads an AVAudioFile into the current player node
   private func loadFile(_ file: AVAudioFile) {
     playerNode.scheduleFile(file, at: nil)
@@ -249,6 +261,7 @@ public class SpinPlayer {
 
     do {
       currentFile = try AVAudioFile(forReading: url)
+      normalizationCalculator = AudioNormalizationCalculator(currentFile!)
     } catch {
       os_log("Error loading (%@): %@",
              log: SpinPlayer.logger,
@@ -258,7 +271,7 @@ public class SpinPlayer {
   }
 
   // MARK: Tap
-  
+
   /// Handles the audio tap
   private func onTap(_ buffer: AVAudioPCMBuffer, _ time: AVAudioTime) {
     guard let file = currentFile,
@@ -267,7 +280,7 @@ public class SpinPlayer {
             forNodeTime: nodeTime) else {
       return
     }
-    
+
     let currentTime = TimeInterval(playerTime.sampleTime) / playerTime.sampleRate
     delegate?.player(self, didPlayFile: file, atTime: currentTime, withBuffer: buffer)
   }
@@ -280,8 +293,8 @@ public class SpinPlayer {
 
     // for now, fire a
     self.clearTimer = Timer(fire: endtime.addingTimeInterval(1),
-                                  interval: 0,
-                                  repeats: false, block: { timer in
+                            interval: 0,
+                            repeats: false, block: { timer in
       DispatchQueue.main.async {
         self.stopAudio()
         self.clear()


### PR DESCRIPTION
This pull request introduces a new `AudioNormalizationCalculator` to the `PlayolaPlayer` project and integrates it into the `SpinPlayer` class to handle audio normalization. The most important changes are:

### Addition of `AudioNormalizationCalculator`:

* [`Sources/PlayolaPlayer/Player/AudioNormalizationCalculator.swift`](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9R1-R54): Created a new `AudioNormalizationCalculator` struct to calculate and adjust audio normalization based on amplitude. This includes methods for getting samples and calculating amplitude, as well as methods for adjusting and retrieving player volume.

### Integration with `SpinPlayer`:

* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R57-R58): Added a `normalizationCalculator` property to the `SpinPlayer` class and updated the `volume` property to use this calculator for volume adjustments. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R57-R58) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R68-R87)
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L155-R166): Modified the `scheduleSegment` and `schedulePlay` methods to set the volume using the new normalization logic. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L155-R166) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R202)
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R264): Updated the `currentFile` property to initialize the `normalizationCalculator` with the new audio file.