### PR TITLE
Fades

### DIFF
--- a/Sources/PlayolaPlayer/Models/Spin.swift
+++ b/Sources/PlayolaPlayer/Models/Spin.swift
@@ -6,6 +6,11 @@
 //
 import Foundation
 
+public struct Fade: Codable, Sendable {
+  let atMS: Int
+  let toVolume: Float
+}
+
 public struct Spin: Codable, Sendable {
   let id: String
   let stationId: String
@@ -13,6 +18,7 @@ public struct Spin: Codable, Sendable {
   let createdAt: Date
   let updatedAt: Date
   let audioBlock: AudioBlock?
+  let fades: [Fade]
 
   // dependency injection
   var dateProvider: DateProvider! = .shared
@@ -27,7 +33,7 @@ public struct Spin: Codable, Sendable {
   }
 
   private enum CodingKeys: String, CodingKey {
-    case id, stationId, airtime, createdAt, updatedAt, audioBlock
+    case id, stationId, airtime, createdAt, updatedAt, audioBlock, fades
   }
 }
 


### PR DESCRIPTION
This pull request introduces a new `Fade` struct and integrates fade functionality into the `SpinPlayer` class. The changes include adding a new property to the `Spin` struct, managing fade timers, and implementing the fade logic in the player.

Key changes:

### New Struct Addition:
* [`Sources/PlayolaPlayer/Models/Spin.swift`](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR9-R21): Added a new `Fade` struct to represent fade operations with `atMS` and `toVolume` properties. This struct is also added to the `Spin` struct as a new property. [[1]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR9-R21) [[2]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cL30-R36)

### Fade Functionality in SpinPlayer:
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R32): Added a `fadeTimers` property to manage multiple fade timers.
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R280-R326): Implemented the `fadePlayer` method to handle the fade logic by adjusting the volume over time.
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R280-R326): Added the `scheduleFades` method to schedule fade operations based on the `Spin`'s `fades` property.
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R196): Updated the `load` method to call `scheduleFades` when loading a `Spin`.
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R146-R149): Ensured that all fade timers are invalidated when the player is reset.