### PR TITLE
ListeningSessionReporter

### DIFF
--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -1,0 +1,138 @@
+//
+//  ListeningSessionReporter.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 2/12/25.
+//
+import Combine
+import AVFoundation
+import Foundation
+import UIKit
+
+struct ListeningSessionRequest: Codable {
+  let deviceId: String
+  let stationId: String?
+  let stationUrl: String? = nil
+}
+
+@MainActor
+public class ListeningSessionReporter {
+  var deviceId: String? {
+    return UIDevice.current.identifierForVendor?.uuidString
+  }
+  var timer: Timer?
+  let basicToken = "aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx" // TODO: De-hard-code this
+  var currentSessionStationId: String?
+  var disposeBag = Set<AnyCancellable>()
+  weak var stationPlayer: PlayolaStationPlayer?
+  var currentListeningSessionID: String?
+
+  init(stationPlayer: PlayolaStationPlayer) {
+    self.stationPlayer = stationPlayer
+
+    stationPlayer.$stationId.sink { stationId in
+      if let stationId  {
+        self.reportOrExtendListeningSession(stationId)
+        self.startPeriodicNotifications()
+      } else {
+        self.endListeningSession()
+        self.stopPeriodicNotifications()
+      }
+    }.store(in: &disposeBag)
+  }
+
+  public func endListeningSession() {
+    guard let deviceId else {
+      print("Cannot send listeningSession -- missing identifier")
+      return
+    }
+    let url = URL(string: "https://admin-api.playola.fm/v1/listeningSessions/end")!
+    let requestBody = [ "deviceId": deviceId]
+
+    guard let jsonData = try? JSONEncoder().encode(requestBody) else {
+      print("Error: unable to encode request body to JSON for end listeningSession")
+      return
+    }
+
+    var request = createPostRequest(url: url, jsonData: jsonData)
+    // Create a URLSession task to send the request
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      if let error = error {
+        print("Error: \(error.localizedDescription)")
+        return
+      }
+
+      if let httpResponse = response as? HTTPURLResponse {
+        print("Response Status Code: \(httpResponse.statusCode)")
+      }
+
+      if let data = data, let responseString = String(data: data, encoding: .utf8) {
+        print("Response Data: \(responseString)")
+      }
+    }
+    task.resume()
+  }
+
+  public func reportOrExtendListeningSession(_ stationId: String) {
+    guard let deviceId else {
+      print("Cannot send listeningSession -- missing identifier")
+      return
+    }
+    let url = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+
+    // Create an instance of the Codable struct
+    let requestBody = ListeningSessionRequest(
+      deviceId: deviceId,
+      stationId: stationId)
+
+    // Convert the Codable struct to JSON data
+    guard let jsonData = try? JSONEncoder().encode(requestBody) else {
+      print("Error: Unable to encode request body to JSON")
+      return
+    }
+
+    // Create the request
+    var request = createPostRequest(url: url, jsonData: jsonData)
+
+    // Create a URLSession task to send the request
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      if let error = error {
+        print("Error: \(error.localizedDescription)")
+        return
+      }
+
+      if let httpResponse = response as? HTTPURLResponse {
+        print("Response Status Code: \(httpResponse.statusCode)")
+      }
+
+      if let data = data, let responseString = String(data: data, encoding: .utf8) {
+        print("Response Data: \(responseString)")
+      }
+    }
+    task.resume()
+  }
+
+  private func startPeriodicNotifications() {
+    self.timer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true, block: { [weak self] timer in
+      guard let self else { return }
+      guard let stationId = self.stationPlayer?.stationId else {
+        print("Error -- stationId should exist")
+        return
+      }
+      self.reportOrExtendListeningSession(stationId)
+    })
+  }
+
+  private func stopPeriodicNotifications() {
+    self.timer?.invalidate()
+  }
+
+  private func createPostRequest(url: URL, jsonData: Data) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = jsonData
+    request.addValue("Basic \(basicToken)", forHTTPHeaderField: "Authorization")
+    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    return request
+  }
+}

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -15,9 +15,10 @@ let baseUrl = URL(string: "https://admin-api.playola.fm/v1")!
 
 @MainActor
 final public class PlayolaStationPlayer: ObservableObject {
-  @Published var stationId: String?   // TODO: Change this to Station model
+  @Published public var stationId: String?   // TODO: Change this to Station model
   var currentSchedule: Schedule?
   let fileDownloadManager: FileDownloadManager!
+  var listeningSessionReporter: ListeningSessionReporter? = nil
 
   public weak var delegate: PlayolaStationPlayerDelegate?
 
@@ -47,6 +48,7 @@ final public class PlayolaStationPlayer: ObservableObject {
 
   private init() {
     self.fileDownloadManager = FileDownloadManager()
+    self.listeningSessionReporter = ListeningSessionReporter(stationPlayer: self)
   }
 
   private static let logger = OSLog(


### PR DESCRIPTION
This pull request introduces a new class `ListeningSessionReporter` to handle listening session reporting for the `PlayolaStationPlayer` and makes some related changes to the `PlayolaStationPlayer` class. The most important changes include the creation of the `ListeningSessionReporter` class, its integration into `PlayolaStationPlayer`, and the addition of periodic session reporting.

### New Class Implementation:

* [`Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift`](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013R1-R138): Introduced a new class `ListeningSessionReporter` to manage listening session reporting, including methods to start, extend, and end sessions, and to send periodic notifications.

### Integration with `PlayolaStationPlayer`:

* [`Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift`](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL18-R21): Added a new property `listeningSessionReporter` to `PlayolaStationPlayer` and initialized it in the constructor to integrate the new session reporting functionality. [[1]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL18-R21) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR51)