### PR TITLE
Add StartingVolume to Spin

### DIFF
--- a/Sources/PlayolaPlayer/Models/Spin.swift
+++ b/Sources/PlayolaPlayer/Models/Spin.swift
@@ -15,6 +15,7 @@ public struct Spin: Codable, Sendable {
   let id: String
   let stationId: String
   let airtime: Date
+  let startingVolume: Float
   let createdAt: Date
   let updatedAt: Date
   let audioBlock: AudioBlock?
@@ -33,7 +34,7 @@ public struct Spin: Codable, Sendable {
   }
 
   private enum CodingKeys: String, CodingKey {
-    case id, stationId, airtime, createdAt, updatedAt, audioBlock, fades
+    case id, stationId, airtime, createdAt, updatedAt, audioBlock, fades, startingVolume
   }
 }
 

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -189,10 +189,11 @@ public class SpinPlayer {
       if spin.isPlaying {
         let currentTimeInSeconds = Date().timeIntervalSince(spin.airtime)
         self.playNow(from: currentTimeInSeconds)
+        self.volume = 1.0
       } else {
         self.schedulePlay(at: spin.airtime)
+        self.volume = spin.startingVolume
       }
-      self.volume = 1.0
       self.scheduleFades(spin)
       self.state = .loaded
     }


### PR DESCRIPTION
This pull request introduces changes to the `Spin` model and the `SpinPlayer` class to incorporate a new `startingVolume` attribute. The changes ensure that the `startingVolume` is correctly encoded/decoded and used during playback.

Changes to `Spin` model:

* [`Sources/PlayolaPlayer/Models/Spin.swift`](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR18): Added a new property `startingVolume` to the `Spin` struct and updated the `CodingKeys` enum to include `startingVolume`. [[1]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR18) [[2]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cL36-R37)

Changes to `SpinPlayer` class:

* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R192-L195): Adjusted the `SpinPlayer` class to set the volume based on the `startingVolume` attribute when a spin is scheduled to play.