### PR TITLE
Centralize AVAudioEngine Setup

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -33,6 +33,7 @@ open class PlayolaMainMixer: NSObject {
     open var engine: AVAudioEngine!
     open var delegate: PlayolaMainMixerDelegate?
     private let errorReporter = PlayolaErrorReporter.shared
+    private var isAudioSessionConfigured = false
 
     private static let logger = OSLog(subsystem: "fm.playola.playolaCore", category: "MainMixer")
 
@@ -65,6 +66,117 @@ open class PlayolaMainMixer: NSObject {
             // Cannot report via errorReporter in deinit as it might be async
             // For deinit errors, we'll keep using os_log
             os_log("Error removing tap during deinit: %@", log: PlayolaMainMixer.logger, type: .error, error.localizedDescription)
+        }
+    }
+
+    /// Configures the shared audio session for playback
+    public func configureAudioSession() {
+        guard !isAudioSessionConfigured else { return }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+
+            // First deactivate with appropriate options to reset state
+            try? session.setActive(false, options: .notifyOthersOnDeactivation)
+
+            // Configure for playback category
+            try session.setCategory(
+                .playback,
+                mode: .default,
+                options: [
+                    .allowBluetoothA2DP,
+                    .allowAirPlay,
+                ]
+            )
+
+            // Set the audio session active
+            try session.setActive(true)
+            isAudioSessionConfigured = true
+
+            os_log("Audio session successfully configured", log: PlayolaMainMixer.logger, type: .info)
+        } catch {
+            Task { @MainActor in
+                errorReporter.reportError(error, context: "Failed to configure audio session", level: .critical)
+            }
+        }
+    }
+
+    /// Deactivates the audio session when it's no longer needed
+    public func deactivateAudioSession() {
+        guard isAudioSessionConfigured else { return }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+            isAudioSessionConfigured = false
+
+            os_log("Audio session deactivated", log: PlayolaMainMixer.logger, type: .info)
+        } catch {
+            Task { @MainActor in
+                errorReporter.reportError(error, context: "Failed to deactivate audio session", level: .warning)
+            }
+        }
+    }
+
+    /// Handle audio session interruptions such as phone calls
+    public func handleAudioSessionInterruption(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+            return
+        }
+
+        switch type {
+        case .began:
+            // Audio session was interrupted - might need to pause playback
+            os_log("Audio session interrupted", log: PlayolaMainMixer.logger, type: .info)
+
+        case .ended:
+            // Interruption ended - might need to resume playback
+            guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+                return
+            }
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+
+            if options.contains(.shouldResume) {
+                // The system indicates that we can resume audio
+                do {
+                    try engine.start()
+                    os_log("Audio engine restarted after interruption", log: PlayolaMainMixer.logger, type: .info)
+                } catch {
+                    Task { @MainActor in
+                        errorReporter.reportError(error, context: "Failed to restart audio engine after interruption", level: .error)
+                    }
+                }
+            }
+
+        @unknown default:
+            os_log("Unknown audio session interruption type: %d", log: PlayolaMainMixer.logger, type: .error, typeValue)
+        }
+    }
+
+    /// Handle audio route changes such as connecting/disconnecting headphones
+    public func handleAudioRouteChange(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else {
+            return
+        }
+
+        // Check if the audio route changed
+        switch reason {
+        case .newDeviceAvailable:
+            // New device (like headphones) was connected
+            os_log("New audio route device available", log: PlayolaMainMixer.logger, type: .info)
+
+        case .oldDeviceUnavailable:
+            // Old device (like headphones) was disconnected
+            // You might want to pause playback here
+            os_log("Audio route device disconnected", log: PlayolaMainMixer.logger, type: .info)
+
+        default:
+            // Handle other route changes if needed
+            os_log("Audio route changed for reason: %d", log: PlayolaMainMixer.logger, type: .info, reasonValue)
         }
     }
 

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -91,26 +91,8 @@ public class SpinPlayer {
     self.fileDownloadManager = fileDownloadManager ?? .shared
     self.delegate = delegate
 
-    do {
-      // Get the shared AVAudioSession instance - this is the recommended approach
-      let session = AVAudioSession.sharedInstance()
-
-      // Configure for playback category - note that .defaultToSpeaker is removed
-      // as it's only applicable with .playAndRecord category
-      try session.setCategory(
-        .playback,
-        mode: .default,
-        options: [
-          .allowBluetoothA2DP,
-          .allowAirPlay,
-        ])
-
-      // Also set the audio session active - best practice
-      try session.setActive(true)
-    } catch {
-      // Report error through the central error reporter
-      errorReporter.reportError(error, context: "Failed to set up audio session", level: .critical)
-    }
+    // Use the centralized audio session management instead of configuring here
+    playolaMainMixer.configureAudioSession()
 
     /// Make connections
     engine.attach(playerNode)
@@ -133,6 +115,8 @@ public class SpinPlayer {
   private func stopAudio() {
     if !engine.isRunning {
       do {
+        // Make sure audio session is configured before starting engine
+        playolaMainMixer.configureAudioSession()
         try engine.start()
       } catch {
         errorReporter.reportError(error, context: "Failed to start engine during stop operation", level: .error)
@@ -159,6 +143,8 @@ public class SpinPlayer {
   /// play a segment of the song immediately
   private func playNow(from: Double, to: Double? = nil) {
     do {
+      // Make sure audio session is configured before playback
+      playolaMainMixer.configureAudioSession()
       try engine.start()
 
       // calculate segment info
@@ -231,6 +217,8 @@ public class SpinPlayer {
   /// schedule a future play from the beginning of the file
   public func schedulePlay(at scheduledDate: Date) {
     do {
+      // Make sure audio session is configured before scheduling playback
+      playolaMainMixer.configureAudioSession()
       try engine.start()
       let avAudiotime = avAudioTimeFromDate(date: scheduledDate)
       playerNode.play(at: avAudiotime)


### PR DESCRIPTION
This pull request introduces significant updates to the audio session management in the `PlayolaMainMixer` and `SpinPlayer` classes. The changes centralize audio session configuration and handling, improving maintainability and consistency across the codebase.

### Audio session management improvements:

* [`Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift`](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fR72-R182): Added methods to configure, deactivate, and handle interruptions and route changes for the audio session. This includes `configureAudioSession`, `deactivateAudioSession`, `handleAudioSessionInterruption`, and `handleAudioRouteChange`.
* [`Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift`](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fR36): Introduced a private variable `isAudioSessionConfigured` to track the audio session state.

### Refactoring in `SpinPlayer`:

* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L94-R95): Replaced direct audio session configuration with calls to `playolaMainMixer.configureAudioSession` in multiple methods to ensure the audio session is properly configured before starting playback or scheduling. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L94-R95) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R118-R119) [[3]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R146-R147) [[4]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R220-R221)