### PR TITLE
Chore: Memory Cleanup

### DIFF
--- a/Sources/PlayolaPlayer/Player/FileDownloader.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloader.swift
@@ -29,7 +29,10 @@ public final class FileDownloader: NSObject, @unchecked Sendable {
     self.remoteUrl = remoteUrl
     self.localUrl = localUrl
     self.handleProgressBlock = onProgress
-    self.handleCompletionBlock = onCompletion
+    self.handleCompletionBlock = { [weak self] downloader in
+      guard let self else { return }
+      onCompletion?(downloader)
+    }
     self.session = URLSession(configuration: .default,
                               delegate: self,
                               delegateQueue: .main)

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -64,6 +64,11 @@ public class ListeningSessionReporter {
     }.store(in: &disposeBag)
   }
 
+  deinit {
+    self.timer?.invalidate()
+    disposeBag.removeAll()
+  }
+
   public func endListeningSession() {
     guard let deviceId else {
       let error = ListeningSessionError.missingDeviceId

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -87,18 +87,20 @@ final public class PlayolaStationPlayer: ObservableObject {
 
   @MainActor
   private func scheduleSpin(spin: Spin, completion: (() -> Void)? = nil) {
-    let spinPlayer = getAvailableSpinPlayer()
-    if spin.isPlaying {
-      spinPlayer.load(spin, onDownloadProgress: { progress in
-        self.state = .loading(progress)
-      }, onDownloadCompletion: { localUrl in
-        completion?()
-        self.state = .playing(spin.audioBlock!)
-      })
-    } else {
-      spinPlayer.load(spin)
-      completion?()
-    }
+      let spinPlayer = getAvailableSpinPlayer()
+      if spin.isPlaying {
+          spinPlayer.load(spin, onDownloadProgress: { [weak self] progress in
+              guard let self = self else { return }
+              self.state = .loading(progress)
+          }, onDownloadCompletion: { [weak self] localUrl in
+              guard let self = self else { return }
+              completion?()
+              self.state = .playing(spin.audioBlock!)
+          })
+      } else {
+          spinPlayer.load(spin)
+          completion?()
+      }
   }
 
   @MainActor


### PR DESCRIPTION
This pull request includes several important changes to improve memory management and performance in the `PlayolaPlayer` module. The changes include adding weak references to prevent retain cycles, implementing a deinitializer to clean up resources, and optimizing the volume fade logic in `SpinPlayer`.

Memory management improvements:

* [`Sources/PlayolaPlayer/Player/FileDownloader.swift`](diffhunk://#diff-a13934af3d9bb9217ff7fe6435caa0734700fb546ff472c114ced3397ada4e0cL32-R35): Modified the `handleCompletionBlock` to use a weak reference to `self` to prevent retain cycles.
* [`Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift`](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL92-R96): Added weak references in the `scheduleSpin` method to avoid retain cycles when updating the state during download progress and completion.

Resource cleanup:

* [`Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift`](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013R67-R71): Added a `deinit` method to invalidate the timer and clear the `disposeBag` to ensure proper resource cleanup when the instance is deallocated.

Performance optimization:

* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L295-R316): Replaced multiple dispatch blocks with a single timer for updating the volume during a fade, improving performance and reducing complexity.