### PR TITLE
Bugfix: Spin Randomly Plays After Station is Stopped

### DIFF
--- a/Sources/PlayolaPlayer/Player/FileDownloadManager.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloadManager.swift
@@ -17,7 +17,7 @@ public enum FileDownloadError: Error, LocalizedError {
   case cachePruneFailed(String)
   case downloadCancelled
   case unknownError
-  
+
   public var errorDescription: String? {
     switch self {
     case .directoryCreationFailed(let path):
@@ -58,7 +58,7 @@ public protocol FileDownloadManaging {
     progressHandler: @escaping (Float) -> Void,
     completion: @escaping (Result<URL, FileDownloadError>) -> Void
   ) -> UUID
-  
+
   /// Downloads a file asynchronously from a remote URL
   /// - Parameters:
   ///   - remoteUrl: The URL of the file to download
@@ -69,47 +69,47 @@ public protocol FileDownloadManaging {
     remoteUrl: URL,
     progressHandler: ((Float) -> Void)?
   ) async throws -> URL
-  
+
   /// Cancels a specific download using its identifier
   /// - Parameter downloadId: The identifier of the download to cancel
   /// - Returns: True if a download was found and cancelled, false otherwise
   @discardableResult
   func cancelDownload(id downloadId: UUID) -> Bool
-  
+
   /// Cancels all downloads for a specific remote URL
   /// - Parameter remoteUrl: The remote URL of the downloads to cancel
   /// - Returns: The number of downloads cancelled
   @discardableResult
   func cancelDownload(for remoteUrl: URL) -> Int
-  
+
   /// Cancels all active downloads
   func cancelAllDownloads()
-  
+
   /// Checks if a file already exists in the cache
   /// - Parameter remoteUrl: The remote URL to check
   /// - Returns: True if the file exists in the cache
   func fileExists(for remoteUrl: URL) -> Bool
-  
+
   /// Returns the local URL where a file would be stored
   /// - Parameter remoteUrl: The remote URL of the file
   /// - Returns: The local cache URL for this file
   func localURL(for remoteUrl: URL) -> URL
-  
+
   /// Clears all cached files
   /// - Throws: FileDownloadError if the cache couldn't be cleared
   func clearCache() throws
-  
+
   /// Prunes the cache to stay under the specified size limit
   /// - Parameters:
   ///   - maxSize: Maximum size in bytes for the cache (nil uses default)
   ///   - excludeFilepaths: Paths to exclude from pruning
   /// - Throws: FileDownloadError if pruning fails
   func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws
-  
+
   /// Returns the current size of the cache in bytes
   /// - Returns: The size in bytes
   func currentCacheSize() -> Int64
-  
+
   /// Returns the available disk space on the volume containing the cache
   /// - Returns: Available space in bytes, or nil if it couldn't be determined
   func availableDiskSpace() -> Int64?
@@ -136,36 +136,36 @@ public final class FileDownloadManager: FileDownloadManaging {
   /// Maximum default size of the audio file cache in bytes (50MB)
   /// This limit can be overridden in the pruneCache method
   public static let MAX_AUDIO_FOLDER_SIZE: Int64 = 52_428_800
-  
+
   /// Name of the cache subfolder
   public static let subfolderName = "AudioFiles"
-  
+
   /// Shared singleton instance
   public static let shared = FileDownloadManager()
-  
+
   /// Active downloaders keyed by their unique identifiers
   private var downloaders: [UUID: FileDownloader] = [:]
-  
+
   /// Error reporter for logging issues
   private let errorReporter = PlayolaErrorReporter.shared
-  
+
   /// Queue for synchronizing access to shared resources
   private let downloadQueue = DispatchQueue(label: "fm.playola.fileDownloadManager", qos: .utility)
-  
+
   /// Logger for debug information
   private static let logger = OSLog(subsystem: "fm.playola.playolaCore", category: "FileDownloadManager")
-  
+
   /// Initializes a new file download manager and creates the cache directory
   public init() {
     createFolderIfNotExist()
   }
-  
+
   deinit {
     Task {
       await cancelAllDownloads()
     }
   }
-  
+
   /// The URL of the cache directory
   private var fileDirectoryURL: URL! {
     let paths = NSSearchPathForDirectoriesInDomains(
@@ -176,7 +176,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     return documentsDirectoryURL.appendingPathComponent(
       FileDownloadManager.subfolderName)
   }
-  
+
   /// Returns the local URL where a remote file would be stored
   /// - Parameter remoteUrl: The remote URL of the file
   /// - Returns: The local cache URL for this file
@@ -184,7 +184,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     let filename = remoteUrl.lastPathComponent
     return fileDirectoryURL.appendingPathComponent(filename)
   }
-  
+
   /// Creates the cache directory if it doesn't exist
   private func createFolderIfNotExist() {
     let fileManager = FileManager.default
@@ -198,7 +198,7 @@ public final class FileDownloadManager: FileDownloadManaging {
                                 level: .error) // Elevated to error since this is critical functionality
     }
   }
-  
+
   /// Checks if a file already exists in the cache
   /// - Parameter remoteUrl: The remote URL to check
   /// - Returns: True if the file exists in the cache
@@ -206,7 +206,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     let localUrl = localURL(for: remoteUrl)
     return FileManager.default.fileExists(atPath: localUrl.path)
   }
-  
+
   /// Downloads a file from a remote URL
   /// - Parameters:
   ///   - remoteUrl: The URL of the file to download
@@ -220,50 +220,53 @@ public final class FileDownloadManager: FileDownloadManaging {
     completion: @escaping (Result<URL, FileDownloadError>) -> Void
   ) -> UUID {
     let localUrl = localURL(for: remoteUrl)
-    
-    // Check if file already exists
-    // More detailed error handling
-    if FileManager.default.fileExists(atPath: localUrl.path) {
-      completion(.success(localUrl))
-      return UUID() // Return a dummy ID since no download was started
-    } else {
-      // Check if we have sufficient storage space
-      if let availableSpace = availableDiskSpace(),
-         availableSpace < 10_485_760 { // 10MB minimum
-        let error = FileDownloadError.cachePruneFailed("Insufficient storage space: \(availableSpace / 1_048_576) MB available")
-        completion(.failure(error))
-        errorReporter.reportError(error, level: .warning)
-        return UUID()
-      }
-    }
-    
     let downloadId = UUID()
-    let downloader = FileDownloader(
-      id: downloadId,
-      remoteUrl: remoteUrl,
-      localUrl: localUrl,
-      onProgress: progressHandler,
-      onCompletion: { [weak self] downloader in
-        guard let self = self else { return }
-        self.safelyRemoveDownloader(downloadId)
-        completion(.success(downloader.localUrl))
-      },
-      onError: { [weak self] error in
-        guard let self = self else { return }
-        self.safelyRemoveDownloader(downloadId)
-        
-        if let downloadError = error as? FileDownloadError {
-          completion(.failure(downloadError))
-        } else {
-          completion(.failure(.downloadFailed(error.localizedDescription)))
+
+    // Check if file already exists
+    if FileManager.default.fileExists(atPath: localUrl.path) {
+        Task { @MainActor in
+            completion(.success(localUrl))
         }
-      }
+        return downloadId // Return a dummy ID since no download was started
+    }
+
+    // Check if we have sufficient storage space
+    if let availableSpace = availableDiskSpace(),
+       availableSpace < 10_485_760 { // 10MB minimum
+        let error = FileDownloadError.cachePruneFailed("Insufficient storage space: \(availableSpace / 1_048_576) MB available")
+        Task { @MainActor in
+            completion(.failure(error))
+            errorReporter.reportError(error, level: .warning)
+        }
+        return downloadId
+    }
+
+    let downloader = FileDownloader(
+        id: downloadId,
+        remoteUrl: remoteUrl,
+        localUrl: localUrl,
+        onProgress: progressHandler,
+        onCompletion: { [weak self] downloader in
+            guard let self = self else { return }
+            self.safelyRemoveDownloader(downloadId)
+            completion(.success(downloader.localUrl))
+        },
+        onError: { [weak self] error in
+            guard let self = self else { return }
+            self.safelyRemoveDownloader(downloadId)
+
+            if let downloadError = error as? FileDownloadError {
+                completion(.failure(downloadError))
+            } else {
+                completion(.failure(.downloadFailed(error.localizedDescription)))
+            }
+        }
     )
-    
+
     safelyAddDownloader(downloadId, downloader)
     return downloadId
   }
-  
+
   /// Downloads a file asynchronously from a remote URL
   /// - Parameters:
   ///   - remoteUrl: The URL of the file to download
@@ -289,7 +292,7 @@ public final class FileDownloadManager: FileDownloadManaging {
       )
     }
   }
-  
+
   /// Cancels a specific download using its identifier
   /// - Parameter downloadId: The identifier of the download to cancel
   /// - Returns: True if a download was found and cancelled, false otherwise
@@ -305,7 +308,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     }
     return cancelled
   }
-  
+
   /// Cancels all downloads for a specific remote URL
   /// - Parameter remoteUrl: The remote URL of the downloads to cancel
   /// - Returns: The number of downloads cancelled
@@ -313,12 +316,12 @@ public final class FileDownloadManager: FileDownloadManaging {
   public func cancelDownload(for remoteUrl: URL) -> Int {
     var cancelCount = 0
     let localUrl = localURL(for: remoteUrl)
-    
+
     downloadQueue.sync {
       let matchingDownloaders = downloaders.values.filter {
         $0.remoteUrl == remoteUrl || $0.localUrl == localUrl
       }
-      
+
       for downloader in matchingDownloaders {
         downloader.cancel()
         downloaders.removeValue(forKey: downloader.id)
@@ -327,7 +330,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     }
     return cancelCount
   }
-  
+
   /// Cancels all active downloads
   public func cancelAllDownloads() {
     downloadQueue.sync {
@@ -337,36 +340,36 @@ public final class FileDownloadManager: FileDownloadManaging {
       downloaders.removeAll()
     }
   }
-  
+
   // Thread-safe methods to modify downloaders collection
   private func safelyAddDownloader(_ id: UUID, _ downloader: FileDownloader) {
     downloadQueue.sync {
       downloaders[id] = downloader
     }
   }
-  
+
   private func safelyRemoveDownloader(_ id: UUID) {
     downloadQueue.sync {
       downloaders.removeValue(forKey: id)
     }
   }
-  
+
   /// Clears all cached files
   /// - Throws: FileDownloadError if the cache couldn't be cleared
   public func clearCache() throws {
     guard let directory = fileDirectoryURL else {
       throw FileDownloadError.directoryCreationFailed("No directory URL available")
     }
-    
+
     let fileManager = FileManager.default
-    
+
     do {
       let fileURLs = try fileManager.contentsOfDirectory(
         at: directory,
         includingPropertiesForKeys: nil,
         options: .skipsHiddenFiles
       )
-      
+
       for fileURL in fileURLs {
         try fileManager.removeItem(at: fileURL)
       }
@@ -374,13 +377,13 @@ public final class FileDownloadManager: FileDownloadManaging {
       throw FileDownloadError.cachePruneFailed("Failed to clear cache: \(error.localizedDescription)")
     }
   }
-  
+
   /// Returns the current size of the cache in bytes
   /// - Returns: The size in bytes
   public func currentCacheSize() -> Int64 {
     return calculateFolderCacheSize()
   }
-  
+
   /// Returns the available disk space on the volume containing the cache
   /// - Returns: Available space in bytes, or nil if it couldn't be determined
   public func availableDiskSpace() -> Int64? {
@@ -396,26 +399,26 @@ public final class FileDownloadManager: FileDownloadManaging {
       return nil
     }
   }
-  
+
   /// Calculates the total size of files in the cache folder
   /// - Returns: Size in bytes
   private func calculateFolderCacheSize() -> Int64 {
     var bool: ObjCBool = false
     var folderFileSizeInBytes: Int64 = 0
-    
+
     guard let cachePath = fileDirectoryURL?.path,
           FileManager.default.fileExists(atPath: cachePath, isDirectory: &bool),
           bool.boolValue else {
       return 0
     }
-    
+
     let fileManager = FileManager.default
     do {
       let files = try fileManager.contentsOfDirectory(
         at: fileDirectoryURL,
         includingPropertiesForKeys: [.fileSizeKey],
         options: [.skipsHiddenFiles])
-      
+
       for file in files {
         do {
           let attributes = try file.resourceValues(forKeys: [.fileSizeKey])
@@ -433,7 +436,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     }
     return folderFileSizeInBytes
   }
-  
+
   /// Prunes the cache to stay under the specified size limit
   ///
   /// This method:
@@ -448,11 +451,11 @@ public final class FileDownloadManager: FileDownloadManaging {
   /// - Throws: FileDownloadError if pruning fails
   public func pruneCache(maxSize: Int64? = nil, excludeFilepaths: [String] = []) throws {
     let maxCacheSize = maxSize ?? FileDownloadManager.MAX_AUDIO_FOLDER_SIZE
-    
+
     guard let directory = fileDirectoryURL else {
       throw FileDownloadError.directoryCreationFailed("No directory URL available")
     }
-    
+
     let fileUrls: [URL]
     do {
       fileUrls = try FileManager.default.contentsOfDirectory(
@@ -462,16 +465,16 @@ public final class FileDownloadManager: FileDownloadManaging {
     } catch let error {
       throw FileDownloadError.cachePruneFailed("Failed to get directory contents: \(error.localizedDescription)")
     }
-    
+
     // Get current cache size and check if pruning is needed
     let currentSize = currentCacheSize()
     if currentSize <= maxCacheSize {
       return // No pruning needed
     }
-    
+
     // Amount to remove to get under the limit (plus some buffer)
     let amountToDelete = currentSize - maxCacheSize + (1024 * 1024) // 1MB buffer
-    
+
     // Sort files by date (oldest first)
     let filesToPrune = fileUrls.compactMap { url -> (URL, Date, Int64)? in
       do {
@@ -488,7 +491,7 @@ public final class FileDownloadManager: FileDownloadManaging {
     }
       .filter { !excludeFilepaths.contains($0.0.path) }
       .sorted { $0.1 < $1.1 } // Sort by date (oldest first)
-    
+
     // After sorting files for pruning, log which files might be pruned
     if filesToPrune.count > 0 {
       os_log("Pruning candidates: %@",
@@ -496,7 +499,7 @@ public final class FileDownloadManager: FileDownloadManaging {
              type: .debug,
              filesToPrune.map { $0.0.lastPathComponent }.joined(separator: ", "))
     }
-    
+
     // Also log the excluded files
     if !excludeFilepaths.isEmpty {
       os_log("Files excluded from pruning: %@",
@@ -504,15 +507,15 @@ public final class FileDownloadManager: FileDownloadManaging {
              type: .debug,
              excludeFilepaths.map { URL(fileURLWithPath: $0).lastPathComponent }.joined(separator: ", "))
     }
-    
+
     var totalRemoved: Int64 = 0
     let fileManager = FileManager.default
-    
+
     for (url, _, size) in filesToPrune {
       if totalRemoved >= amountToDelete {
         break
       }
-      
+
       do {
         try fileManager.removeItem(at: url)
         totalRemoved += size
@@ -522,7 +525,7 @@ public final class FileDownloadManager: FileDownloadManaging {
         errorReporter.reportError(error, context: "Error removing file during cache pruning: \(url.path)", level: .warning)
       }
     }
-    
+
     if totalRemoved < amountToDelete {
       os_log("Cache pruning incomplete: removed %d bytes of %d needed", log: FileDownloadManager.logger, type: .info, totalRemoved, amountToDelete)
     }

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -176,8 +176,6 @@ public class SpinPlayer {
       _ = fileDownloadManager.cancelDownload(id: activeDownloadId)
       self.activeDownloadId = nil
     }
-
-    stopAudio()
     clear()
   }
 
@@ -198,21 +196,28 @@ public class SpinPlayer {
 
   private func clear() {
     stopAudio()
-
-    // Stop all active fades
-    activeDisplayLink?.invalidate()
-    activeDisplayLink = nil
-    activeFades.removeAll()
+    clearTimers()
+    clearFades()
 
     self.spin = nil
     self.currentFile = nil
     self.state = .available
-    self.clearTimer?.invalidate()
-    self.startNotificationTimer?.invalidate()
-    for timer in fadeTimers {
-      timer.invalidate()
-    }
     self.volume = 1.0
+  }
+
+  func clearTimers() {
+    startNotificationTimer?.invalidate()
+    startNotificationTimer = nil
+    clearTimer?.invalidate()
+    clearTimer = nil
+    fadeTimers.forEach { $0.invalidate() }
+    fadeTimers.removeAll()
+  }
+
+  func clearFades() {
+    activeDisplayLink?.invalidate()
+    activeDisplayLink = nil
+    activeFades.removeAll()
   }
 
   /// Plays the loaded spin immediately from the specified position.
@@ -615,7 +620,7 @@ public class SpinPlayer {
       self.clearTimer?.invalidate()
       return
     }
-    
+
     // for now, fire a timer. Later we should try and use a callback
     self.clearTimer = Timer(fire: endtime.addingTimeInterval(1),
                             interval: 0,


### PR DESCRIPTION
This pull request includes changes to improve the file download management and the audio player cleanup process in the `PlayolaPlayer` module. The most important changes involve adding detailed error handling and organizing cleanup methods for better code readability and maintainability.

### Improvements to File Download Management:

* [`Sources/PlayolaPlayer/Player/FileDownloadManager.swift`](diffhunk://#diff-9dfd18d54d1430da4d041b4e68e150a5ee00bbd389292a09b99e21171d3d918fR223-L240): Added a `Task` to ensure completion handlers run on the main actor for better thread safety and replaced dummy UUID returns with a consistent `downloadId`.

### Improvements to Audio Player Cleanup:

* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L179-L180): Removed redundant `stopAudio` call from the `cancelDownload` method to streamline the cleanup process.
* [`Sources/PlayolaPlayer/Player/SpinPlayer.swift`](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L201-R222): Refactored the `clear` method by extracting timer and fade cleanup into separate `clearTimers` and `clearFades` methods for better code organization and readability.