### PR TITLE
Make Schedule Conform to Sendable Protocol

### DIFF
--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -8,7 +8,8 @@
 import Foundation
 import Combine
 
-public class Schedule: ObservableObject {
+@Observable
+final public class Schedule: Sendable {
     public let id = UUID()
     public let stationId: String
     public let spins: [Spin]
@@ -17,7 +18,7 @@ public class Schedule: ObservableObject {
 
     private var nowPlayingTimer: Timer?
 
-    @Published public private(set) var nowPlaying: Spin?
+    public private(set) var nowPlaying: Spin?
 
     public init(stationId: String,
                 spins: [Spin],


### PR DESCRIPTION
This pull request includes several updates to the `Sources/PlayolaPlayer` module, focusing on making classes conform to `Sendable` and improving the immutability of certain classes. The most important changes include modifying the `Schedule` class, updating the `TimerProvider` protocol, and making the `LiveTimerProvider` and `TestTimerProvider` classes final.

### Updates to `Sources/PlayolaPlayer` module:

* **Schedule class:**
  * Changed `Schedule` to be a `final` class and conform to `Sendable`.
  * Removed the `@Published` property wrapper from the `nowPlaying` property.

* **TimerProvider protocol:**
  * Added `Sendable` conformance to the `TimerProvider` protocol.

* **LiveTimerProvider and TestTimerProvider classes:**
  * Made `LiveTimerProvider` a `final` class.
  * Made `TestTimerProvider` a `final` class and added `@unchecked Sendable` conformance.

* **Exploratory code for future improvements:**
  * Added commented-out code for exploring better mocking of `TimerProvider`.