### PR TITLE
Make Schedule.nowPlaying setter public (private set hides publisher)

### DIFF
--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -18,7 +18,7 @@ final public class Schedule: Sendable {
 
     private var nowPlayingTimer: Timer?
 
-    public private(set) var nowPlaying: Spin?
+    public var nowPlaying: Spin?
 
     public init(stationId: String,
                 spins: [Spin],


### PR DESCRIPTION
This pull request includes a small change to the `Schedule` class in the `Sources/PlayolaPlayer/Models/Schedule.swift` file. The change modifies the `nowPlaying` property to make it publicly settable. 

* [`Sources/PlayolaPlayer/Models/Schedule.swift`](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L21-R21): Changed the `nowPlaying` property from `public private(set)` to `public` to allow external modification.