### PR TITLE
Convert Schedule to ObservableObject

### DIFF
--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -8,8 +8,7 @@
 import Foundation
 import Combine
 
-@Observable
-final public class Schedule: Sendable {
+final public class Schedule: ObservableObject, Sendable {
     public let id = UUID()
     public let stationId: String
     public let spins: [Spin]
@@ -18,7 +17,7 @@ final public class Schedule: Sendable {
 
     private var nowPlayingTimer: Timer?
 
-    public var nowPlaying: Spin?
+    @Published public var nowPlaying: Spin?
 
     public init(stationId: String,
                 spins: [Spin],


### PR DESCRIPTION
This pull request includes changes to the `Schedule` class in the `Sources/PlayolaPlayer/Models/Schedule.swift` file to improve its observability and reactivity. The most important changes include making the `Schedule` class conform to `ObservableObject` and marking the `nowPlaying` property as `@Published`.

Improvements to observability and reactivity:

* [`Sources/PlayolaPlayer/Models/Schedule.swift`](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L11-R11): Changed the `Schedule` class to conform to `ObservableObject` instead of using the custom `@Observable` attribute.
* [`Sources/PlayolaPlayer/Models/Schedule.swift`](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L21-R20): Marked the `nowPlaying` property as `@Published` to enable SwiftUI views to react to changes in this property.