### PR TITLE
Simplify Schedule to Struct

### DIFF
--- a/Tests/PlayolaPlayerTests/ScheduleTests.swift
+++ b/Tests/PlayolaPlayerTests/ScheduleTests.swift
@@ -460,26 +460,4 @@ struct ScheduleTests {
 
         #expect(schedule.nowPlaying == nil)
     }
-
-    @Test("Schedule cleans up timer on deinit")
-    func testTimerCleanup() throws {
-        let mockTime = Date()
-        let dateProviderMock = DateProviderMock(mockDate: mockTime)
-
-        var schedule: Schedule? = Schedule(
-            stationId: "test-station",
-            spins: [Spin.mockWith(
-                airtime: mockTime.addingTimeInterval(30),
-                audioBlock: AudioBlock.mockWith(durationMS: 30000),
-                dateProvider: dateProviderMock
-            )]
-        )
-
-        // Force deallocation
-        weak var weakSchedule = schedule
-        schedule = nil
-
-        // Verify schedule was deallocated (timer didn't retain it)
-        #expect(weakSchedule == nil)
-    }
 }


### PR DESCRIPTION
Remove the nowPlaying automatic updating -- now that Swift Concurrency is around, it really makes sense to do this in a parent class where needed.

This pull request includes significant changes to the `Schedule` model in the `PlayolaPlayer` module. The changes involve refactoring the `Schedule` class to a struct, simplifying the `nowPlaying` logic, and removing the timer-related functionality.

Refactoring and simplification:

* [`Sources/PlayolaPlayer/Models/Schedule.swift`](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L11-R27): Refactored `Schedule` from a class to a struct and simplified the `nowPlaying` property by removing the timer-based update mechanism. The `nowPlaying` property now directly computes the current playing spin based on the current time. [[1]](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L11-R27) [[2]](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L34-L85)

Test updates:

* [`Tests/PlayolaPlayerTests/ScheduleTests.swift`](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L463-L484): Removed the test that verified the cleanup of the timer on deinitialization, as the timer functionality has been removed from the `Schedule` model.