### PR TITLE
BaseUrl Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,38 @@ targets: [
 
 ## Usage
 
+### Configuration
+
+Before using PlayolaPlayer, you need to configure it with an authentication provider. You can also optionally specify a custom base URL for development or staging environments:
+
+```swift
+import PlayolaPlayer
+
+// Production configuration (default)
+PlayolaStationPlayer.shared.configure(authProvider: myAuthProvider)
+
+// Local development configuration
+PlayolaStationPlayer.shared.configure(
+    authProvider: myAuthProvider,
+    baseURL: URL(string: "http://localhost:3000")!
+)
+
+// Staging environment configuration
+PlayolaStationPlayer.shared.configure(
+    authProvider: myAuthProvider,
+    baseURL: URL(string: "https://staging-api.playola.fm")!
+)
+```
+
 ### Basic Playback
 
 The simplest way to use PlayolaPlayer is through the singleton instance:
 
 ```swift
 import PlayolaPlayer
+
+// Configure first (required)
+PlayolaStationPlayer.shared.configure(authProvider: myAuthProvider)
 
 // Start playing a station
 Task {
@@ -326,6 +352,16 @@ class ErrorHandler: PlayolaErrorReporterDelegate {
 ```
 
 ### Advanced Features
+
+#### Custom Base URL Configuration
+
+You can check the current API configuration after configuring the player:
+
+```swift
+// Access the configured base URL (read-only)
+let currentBaseURL = PlayolaStationPlayer.shared.listeningSessionReporter?.baseURL
+print("API Base URL: \(currentBaseURL?.absoluteString ?? "Not configured")")
+```
 
 #### Audio Session Handling
 

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -10,197 +10,256 @@ import Foundation
 
 @MainActor
 struct ListeningSessionTests {
-
-    @Suite("HTTP Request Authorization Headers")
-    struct RequestHeaders {
-        @Test("Uses Bearer token when auth provider has token")
-        func testUsesBearerTokenWhenProvided() async throws {
-            let mockAuth = MockAuthProvider(currentToken: "valid.jwt.token")
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth)
-            
-            // Create a request using the reporter's createPostRequest method
-            let requestBody = ["test": "data"]
-            let url = URL(string: "https://test.com")!
-            
-            let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
-            
-            // Check that Authorization header contains Bearer token
-            let authHeader = request.value(forHTTPHeaderField: "Authorization")
-            #expect(authHeader == "Bearer valid.jwt.token")
-        }
-        
-        @Test("Uses Basic auth when no token available")
-        func testUsesBasicAuthWhenNoToken() async throws {
-            let mockAuth = MockAuthProvider(currentToken: nil)
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth)
-            
-            let requestBody = ["test": "data"]
-            let url = URL(string: "https://test.com")!
-            
-            let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
-            
-            // Check that Authorization header contains Basic auth
-            let authHeader = request.value(forHTTPHeaderField: "Authorization")
-            #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
-        }
-        
-        @Test("Uses Basic auth when auth provider is nil")
-        func testUsesBasicAuthWhenProviderIsNil() async throws {
-            let reporter = await ListeningSessionReporter(authProvider: nil)
-            
-            let requestBody = ["test": "data"]
-            let url = URL(string: "https://test.com")!
-            
-            let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
-            
-            // Check that Authorization header contains Basic auth
-            let authHeader = request.value(forHTTPHeaderField: "Authorization")
-            #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
-        }
+  
+  @Suite("HTTP Request Authorization Headers")
+  struct RequestHeaders {
+    @Test("Uses Bearer token when auth provider has token")
+    func testUsesBearerTokenWhenProvided() async throws {
+      let mockAuth = MockAuthProvider(currentToken: "valid.jwt.token")
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth)
+      
+      // Create a request using the reporter's createPostRequest method
+      let requestBody = ["test": "data"]
+      let url = URL(string: "https://test.com")!
+      
+      let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
+      
+      // Check that Authorization header contains Bearer token
+      let authHeader = request.value(forHTTPHeaderField: "Authorization")
+      #expect(authHeader == "Bearer valid.jwt.token")
     }
     
-    @Suite("Token Refresh on 401")
-    struct TokenRefreshFlow {
-        @Test("Calls refresh token on 401 response")
-        func testCallsRefreshOn401() async throws {
-            let mockAuth = MockAuthProvider(
-                currentToken: "expired.token",
-                refreshedToken: "fresh.token"
-            )
-            let mockURLSession = MockURLSession()
-            
-            // First request returns 401
-            let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
-            mockURLSession.addResponse(statusCode: 401, url: testURL)
-            
-            // Second request (after refresh) returns 200
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
-            
-            // This should trigger the 401 handling
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Verify that refresh was called
-            #expect(mockAuth.refreshCallCount == 1)
-            
-            // Verify that two HTTP requests were made (initial + retry)
-            #expect(mockURLSession.requestCallCount == 2)
-        }
-        
-        @Test("Handles failed token refresh gracefully")
-        func testHandlesFailedRefresh() async throws {
-            let mockAuth = MockAuthProvider(
-                currentToken: "expired.token",
-                refreshedToken: nil // Refresh fails
-            )
-            let mockURLSession = MockURLSession()
-            
-            // First request returns 401
-            let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
-            mockURLSession.addResponse(statusCode: 401, url: testURL)
-            
-            // Basic auth fallback returns 200
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
-            
-            // This should fall back to Basic auth
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Verify that refresh was called
-            #expect(mockAuth.refreshCallCount == 1)
-            
-            // Verify that two HTTP requests were made (initial + Basic auth fallback)
-            #expect(mockURLSession.requestCallCount == 2)
-        }
-        
-        @Test("Exceeds max refresh attempts and falls back to Basic auth")
-        func testExceedsMaxRefreshAttempts() async throws {
-            let mockAuth = MockAuthProvider(
-                currentToken: "expired.token",
-                refreshedToken: "still.expired.token" // Refresh returns token but still gets 401
-            )
-            let mockURLSession = MockURLSession()
-            
-            let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
-            
-            // First request returns 401
-            mockURLSession.addResponse(statusCode: 401, url: testURL)
-            
-            // All refresh attempts also return 401 (simulating broken refresh token)
-            for _ in 0..<3 {
-                mockURLSession.addResponse(statusCode: 401, url: testURL)
-            }
-            
-            // Final Basic auth fallback returns 200
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
-            
-            // This should exhaust refresh attempts and fall back to Basic auth
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Verify that refresh was called 3 times (max attempts)
-            #expect(mockAuth.refreshCallCount == 3)
-            
-            // Verify correct number of HTTP requests:
-            // 1 initial + 3 refresh attempts + 1 Basic auth fallback = 5
-            #expect(mockURLSession.requestCallCount == 5)
-        }
-        
-        @Test("Resets retry counter after successful request")
-        func testResetsRetryCounterAfterSuccess() async throws {
-            let mockAuth = MockAuthProvider(
-                currentToken: "expired.token",
-                refreshedToken: "fresh.token"
-            )
-            let mockURLSession = MockURLSession()
-            
-            let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
-            
-            // First attempt: 401 then success
-            mockURLSession.addResponse(statusCode: 401, url: testURL)
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
-            
-            // First call should succeed after refresh
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Second attempt: 401 then success (should work again, counter was reset)
-            mockURLSession.addResponse(statusCode: 401, url: testURL)
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            // Second call should also succeed
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Verify that refresh was called twice (once for each attempt)
-            #expect(mockAuth.refreshCallCount == 2)
-            
-            // Verify correct number of HTTP requests: 2 + 2 = 4
-            #expect(mockURLSession.requestCallCount == 4)
-        }
-        
-        @Test("Succeeds on first request when token is valid")
-        func testSucceedsOnFirstRequest() async throws {
-            let mockAuth = MockAuthProvider(currentToken: "valid.token")
-            let mockURLSession = MockURLSession()
-            
-            // First request returns 200 (success)
-            let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
-            mockURLSession.addResponse(statusCode: 200, url: testURL)
-            
-            let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
-            
-            // This should succeed without refreshing
-            try await reporter.reportOrExtendListeningSession("test-station-id")
-            
-            // Verify that refresh was NOT called
-            #expect(mockAuth.refreshCallCount == 0)
-            
-            // Verify that only one HTTP request was made
-            #expect(mockURLSession.requestCallCount == 1)
-        }
+    @Test("Uses Basic auth when no token available")
+    func testUsesBasicAuthWhenNoToken() async throws {
+      let mockAuth = MockAuthProvider(currentToken: nil)
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth)
+      
+      let requestBody = ["test": "data"]
+      let url = URL(string: "https://test.com")!
+      
+      let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
+      
+      // Check that Authorization header contains Basic auth
+      let authHeader = request.value(forHTTPHeaderField: "Authorization")
+      #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
     }
+    
+    @Test("Uses Basic auth when auth provider is nil")
+    func testUsesBasicAuthWhenProviderIsNil() async throws {
+      let reporter = await ListeningSessionReporter(authProvider: nil)
+      
+      let requestBody = ["test": "data"]
+      let url = URL(string: "https://test.com")!
+      
+      let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
+      
+      // Check that Authorization header contains Basic auth
+      let authHeader = request.value(forHTTPHeaderField: "Authorization")
+      #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
+    }
+  }
+  
+  @Suite("Token Refresh on 401")
+  struct TokenRefreshFlow {
+    @Test("Calls refresh token on 401 response")
+    func testCallsRefreshOn401() async throws {
+      let mockAuth = MockAuthProvider(
+        currentToken: "expired.token",
+        refreshedToken: "fresh.token"
+      )
+      let mockURLSession = MockURLSession()
+      
+      // First request returns 401
+      let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      mockURLSession.addResponse(statusCode: 401, url: testURL)
+      
+      // Second request (after refresh) returns 200
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
+      
+      // This should trigger the 401 handling
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Verify that refresh was called
+      #expect(mockAuth.refreshCallCount == 1)
+      
+      // Verify that two HTTP requests were made (initial + retry)
+      #expect(mockURLSession.requestCallCount == 2)
+    }
+    
+    @Test("Handles failed token refresh gracefully")
+    func testHandlesFailedRefresh() async throws {
+      let mockAuth = MockAuthProvider(
+        currentToken: "expired.token",
+        refreshedToken: nil // Refresh fails
+      )
+      let mockURLSession = MockURLSession()
+      
+      // First request returns 401
+      let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      mockURLSession.addResponse(statusCode: 401, url: testURL)
+      
+      // Basic auth fallback returns 200
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
+      
+      // This should fall back to Basic auth
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Verify that refresh was called
+      #expect(mockAuth.refreshCallCount == 1)
+      
+      // Verify that two HTTP requests were made (initial + Basic auth fallback)
+      #expect(mockURLSession.requestCallCount == 2)
+    }
+    
+    @Test("Exceeds max refresh attempts and falls back to Basic auth")
+    func testExceedsMaxRefreshAttempts() async throws {
+      let mockAuth = MockAuthProvider(
+        currentToken: "expired.token",
+        refreshedToken: "still.expired.token" // Refresh returns token but still gets 401
+      )
+      let mockURLSession = MockURLSession()
+      
+      let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      
+      // First request returns 401
+      mockURLSession.addResponse(statusCode: 401, url: testURL)
+      
+      // All refresh attempts also return 401 (simulating broken refresh token)
+      for _ in 0..<3 {
+        mockURLSession.addResponse(statusCode: 401, url: testURL)
+      }
+      
+      // Final Basic auth fallback returns 200
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
+      
+      // This should exhaust refresh attempts and fall back to Basic auth
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Verify that refresh was called 3 times (max attempts)
+      #expect(mockAuth.refreshCallCount == 3)
+      
+      // Verify correct number of HTTP requests:
+      // 1 initial + 3 refresh attempts + 1 Basic auth fallback = 5
+      #expect(mockURLSession.requestCallCount == 5)
+    }
+    
+    @Test("Resets retry counter after successful request")
+    func testResetsRetryCounterAfterSuccess() async throws {
+      let mockAuth = MockAuthProvider(
+        currentToken: "expired.token",
+        refreshedToken: "fresh.token"
+      )
+      let mockURLSession = MockURLSession()
+      
+      let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      
+      // First attempt: 401 then success
+      mockURLSession.addResponse(statusCode: 401, url: testURL)
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
+      
+      // First call should succeed after refresh
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Second attempt: 401 then success (should work again, counter was reset)
+      mockURLSession.addResponse(statusCode: 401, url: testURL)
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      // Second call should also succeed
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Verify that refresh was called twice (once for each attempt)
+      #expect(mockAuth.refreshCallCount == 2)
+      
+      // Verify correct number of HTTP requests: 2 + 2 = 4
+      #expect(mockURLSession.requestCallCount == 4)
+    }
+    
+    @Test("Succeeds on first request when token is valid")
+    func testSucceedsOnFirstRequest() async throws {
+      let mockAuth = MockAuthProvider(currentToken: "valid.token")
+      let mockURLSession = MockURLSession()
+      
+      // First request returns 200 (success)
+      let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      mockURLSession.addResponse(statusCode: 200, url: testURL)
+      
+      let reporter = await ListeningSessionReporter(authProvider: mockAuth, urlSession: mockURLSession)
+      
+      // This should succeed without refreshing
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      // Verify that refresh was NOT called
+      #expect(mockAuth.refreshCallCount == 0)
+      
+      // Verify that only one HTTP request was made
+      #expect(mockURLSession.requestCallCount == 1)
+    }
+  }
+  
+  @Suite("Base URL Configuration")
+  struct BaseURLConfiguration {
+    @Test("Uses custom base URL for listening sessions")
+    func testUsesCustomBaseURL() async throws {
+      let customBaseURL = URL(string: "http://localhost:3000")!
+      let mockSession = MockURLSession()
+      let mockAuth = MockAuthProvider()
+      
+      let reporter = await ListeningSessionReporter(
+        authProvider: mockAuth,
+        urlSession: mockSession,
+        baseURL: customBaseURL
+      )
+      
+      mockSession.addResponse(statusCode: 200, url: customBaseURL.appendingPathComponent("v1/listeningSessions"))
+      
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      #expect(mockSession.lastRequest?.url?.absoluteString == "http://localhost:3000/v1/listeningSessions")
+    }
+    
+    @Test("Uses default production URL when not specified")
+    func testUsesDefaultProductionURL() async throws {
+      let mockSession = MockURLSession()
+      let mockAuth = MockAuthProvider()
+      
+      let reporter = await ListeningSessionReporter(
+        authProvider: mockAuth,
+        urlSession: mockSession
+      )
+      
+      let prodURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+      mockSession.addResponse(statusCode: 200, url: prodURL)
+      
+      try await reporter.reportOrExtendListeningSession("test-station-id")
+      
+      #expect(mockSession.lastRequest?.url?.absoluteString == "https://admin-api.playola.fm/v1/listeningSessions")
+    }
+    
+    @Test("Uses custom base URL for ending sessions")
+    func testEndSessionUsesCustomBaseURL() async throws {
+      let customBaseURL = URL(string: "http://localhost:8080")!
+      let mockSession = MockURLSession()
+      let mockAuth = MockAuthProvider()
+      
+      let reporter = await ListeningSessionReporter(
+        authProvider: mockAuth,
+        urlSession: mockSession,
+        baseURL: customBaseURL
+      )
+      
+      mockSession.addResponse(statusCode: 200, url: customBaseURL.appendingPathComponent("v1/listeningSessions/end"))
+      
+      try await reporter.endListeningSession()
+      
+      #expect(mockSession.lastRequest?.url?.absoluteString == "http://localhost:8080/v1/listeningSessions/end")
+    }
+  }
 }

--- a/Tests/PlayolaPlayerTests/PlayolaPlayerTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaPlayerTests.swift
@@ -1,9 +1,0 @@
-import Testing
-@testable import PlayolaPlayer
-
-struct PlayolaPlayerTests {
-    @Test("Example test")
-    func example() {
-        #expect(true)
-    }
-}

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import Foundation
+@testable import PlayolaPlayer
+
+@MainActor
+struct PlayolaStationPlayerTests {
+
+    @Test("Configure passes custom baseURL to ListeningSessionReporter")
+    func testConfigurePassesBaseURL() async throws {
+        let customBaseURL = URL(string: "http://localhost:5000")!
+        let mockAuthProvider = MockAuthProvider()
+        let mockFileDownloadManager = MockFileDownloadManager()
+        let player = PlayolaStationPlayer(fileDownloadManager: mockFileDownloadManager)
+        
+        player.configure(authProvider: mockAuthProvider, baseURL: customBaseURL)
+        
+        #expect(player.listeningSessionReporter?.baseURL == customBaseURL)
+    }
+    
+    @Test("Configure uses default production baseURL when not specified")
+    func testConfigureUsesDefaultBaseURL() async throws {
+        let mockAuthProvider = MockAuthProvider()
+        let mockFileDownloadManager = MockFileDownloadManager()
+        let player = PlayolaStationPlayer(fileDownloadManager: mockFileDownloadManager)
+        
+        player.configure(authProvider: mockAuthProvider)
+        
+        #expect(player.listeningSessionReporter?.baseURL.absoluteString == "https://admin-api.playola.fm")
+    }
+}

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swift
@@ -1,0 +1,56 @@
+//
+//  MockFileDownloadManager.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 7/11/25.
+//
+
+import Foundation
+@testable import PlayolaPlayer
+
+@MainActor
+class MockFileDownloadManager: FileDownloadManaging {
+  
+  nonisolated func downloadFile(remoteUrl: URL, progressHandler: @escaping (Float) -> Void, completion: @escaping (Result<URL, FileDownloadError>) -> Void) -> UUID {
+    let url = URL(string: "file:///mock/path")!
+    completion(.success(url))
+    return UUID()
+  }
+  
+  func downloadFileAsync(remoteUrl: URL, progressHandler: ((Float) -> Void)?) async throws -> URL {
+    return URL(string: "file:///mock/path")!
+  }
+  
+  nonisolated func cancelDownload(id: UUID) -> Bool {
+    return true
+  }
+  
+  nonisolated func cancelDownload(for remoteUrl: URL) -> Int {
+    return 0
+  }
+  
+  nonisolated func cancelAllDownloads() {
+  }
+  
+  nonisolated func fileExists(for remoteUrl: URL) -> Bool {
+    return false
+  }
+  
+  nonisolated func localURL(for remoteUrl: URL) -> URL {
+    return URL(string: "file:///mock/local/\(remoteUrl.lastPathComponent)")!
+  }
+  
+  nonisolated func clearCache() throws {
+  }
+  
+  nonisolated func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws {
+  }
+  
+  nonisolated func currentCacheSize() -> Int64 {
+    return 0
+  }
+  
+  nonisolated func availableDiskSpace() -> Int64? {
+    return 1000000
+  }
+}

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
@@ -8,34 +8,36 @@ import Foundation
 @testable import PlayolaPlayer
 
 class MockURLSession: URLSessionProtocol {
-    var responses: [(Data, URLResponse)] = []
-    var requestCallCount = 0
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        requestCallCount += 1
-
-        if responses.isEmpty {
-            // Default successful response
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (Data(), response)
-        }
-
-        // Return the first response and remove it (FIFO)
-        return responses.removeFirst()
+  var responses: [(Data, URLResponse)] = []
+  var requestCallCount = 0
+  var lastRequest: URLRequest?
+  
+  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+    requestCallCount += 1
+    lastRequest = request
+    
+    if responses.isEmpty {
+      // Default successful response
+      let response = HTTPURLResponse(
+        url: request.url!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+      )!
+      return (Data(), response)
     }
-
-    func addResponse(data: Data = Data(), statusCode: Int, url: URL? = nil) {
-        let response = HTTPURLResponse(
-            url: url ?? URL(string: "https://test.com")!,
-            statusCode: statusCode,
-            httpVersion: nil,
-            headerFields: nil
-        )!
-        responses.append((data, response))
-    }
+    
+    // Return the first response and remove it (FIFO)
+    return responses.removeFirst()
+  }
+  
+  func addResponse(data: Data = Data(), statusCode: Int, url: URL? = nil) {
+    let response = HTTPURLResponse(
+      url: url ?? URL(string: "https://test.com")!,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+    responses.append((data, response))
+  }
 }


### PR DESCRIPTION
This pull request introduces support for configurable API base URLs in the PlayolaPlayer library, enabling developers to specify custom endpoints for different environments (e.g., development, staging). It also includes updates to the testing framework and utilities to validate the new functionality. Key changes include updates to the `ListeningSessionReporter` and `PlayolaStationPlayer` classes, new tests for base URL configuration, and the addition of mock utilities.

### Feature Enhancements:

* **Configurable API Base URL**: Added the ability to specify a custom `baseURL` when configuring the `PlayolaStationPlayer`. This allows developers to use non-production endpoints for testing or staging. Default behavior uses the production URL. (`README.md` - [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R85) `Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift` - [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL80-R85)
* **Dynamic URL Handling**: Updated `ListeningSessionReporter` to dynamically construct API endpoints using the configured `baseURL`. This replaces hardcoded URLs for session reporting and ending. (`Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift` - [[1]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L112-R114) [[2]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L138-R140)

### Testing Improvements:

* **Base URL Configuration Tests**: Added unit tests to ensure custom and default `baseURL` values are correctly passed and used by `ListeningSessionReporter`. (`Tests/PlayolaPlayerTests/ListeningSessionTests.swift` - [[1]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832R206-R264) `Tests/PlayolaPlayerTests/PlayolaStationPlayerTests.swift` - [[2]](diffhunk://#diff-cf98732a95d59c5373989b1f7f5422e0ecb6c8937ce5cc7def9a07f775f2dd0dR1-R30)
* **Mock Utilities**: Introduced `MockFileDownloadManager` to facilitate testing of file download operations without relying on actual network calls. (`Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swift` - [Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swiftR1-R56](diffhunk://#diff-ea586cdef770533204ab7c80041e5c46ebdfcba7eeb6582064d408e5f4c3d645R1-R56))

### Documentation Updates:

* **Configuration Section**: Expanded the `README.md` to include instructions for configuring `PlayolaPlayer` with custom `baseURL` values for different environments. (`README.md` - [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R356-R365)

### Codebase Simplification:

* **Improved Debugging**: Enhanced `MockURLSession` to track the last request made, aiding in debugging and validation during tests. (`Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift` - [Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swiftR13-R17](diffhunk://#diff-9cea1a0a39ec8be4e727c17b02cea3a82fc797136b912309ffd4990f6a397463R13-R17))