### PR TITLE
Bugfix: Stuttering Audio on Hardware Devices

### DIFF
--- a/Sources/PlayolaPlayer/Player/AudioSessionManager.swift
+++ b/Sources/PlayolaPlayer/Player/AudioSessionManager.swift
@@ -35,7 +35,9 @@ protocol AudioSessionManaging {
 
       // First deactivate with appropriate options to reset state
       do {
-        print("🔊 Calling session.setActive(false, options: .notifyOthersOnDeactivation)")
+        print(
+          "🔊 Calling session.setActive(false, options: .notifyOthersOnDeactivation)"
+        )
         try session.setActive(false, options: .notifyOthersOnDeactivation)
         print("🔊 Successfully deactivated session")
       } catch {
@@ -43,7 +45,8 @@ protocol AudioSessionManaging {
         // This is not a critical error, just log it
         await errorReporter.reportError(
           error,
-          context: "Non-critical error deactivating audio session before configuration",
+          context:
+            "Non-critical error deactivating audio session before configuration",
           level: .warning
         )
       }


### PR DESCRIPTION
This pull request refactors the audio session management and logging in the `PlayolaPlayer` codebase. The most significant change is the removal of the `_isConfigured` state variable in `AudioSessionManager`, replacing it with a computed property that directly checks the audio session's state. Additionally, extensive logging using `os_log` in `SpinPlayer` has been removed, resulting in cleaner and less verbose code. Debug prints have been added to key audio session operations for easier troubleshooting.

### Audio Session Management Refactor

* Removed the `_isConfigured` state variable from `AudioSessionManager` and replaced it with a computed `isConfigured` property that checks the actual state of `AVAudioSession` on iOS, and always returns `true` on macOS. This ensures more reliable session state handling. [[1]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L22-R27) [[2]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L52-R60) [[3]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L66-R80) [[4]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L89-L99)
* Updated methods to use the new `isConfigured` property instead of the old `_isConfigured` variable for activation and deactivation checks. [[1]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L52-R60) [[2]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8L66-R80)

### Logging Changes

* Removed most `os_log` statements from `SpinPlayer`, including those in playback, timer management, file loading, and fade scheduling. This significantly reduces log verbosity and potential performance overhead. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L184-L198) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L225-L230) [[3]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L242-L274) [[4]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L307-L317) [[5]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L339) [[6]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L368-L369) [[7]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L460-L463) [[8]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L500-R450) [[9]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L514-L534) [[10]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L553) [[11]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L593-L595) [[12]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L680-L683) [[13]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L731)

### Debug Print Additions

* Added debug `print` statements to audio session deactivation logic for improved troubleshooting during session state changes.