### PR TITLE
BaseURL for PlayolaStationPlayer (for use with staging)

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -10,8 +10,6 @@ import Combine
 import Foundation
 import os.log
 
-let baseUrl = URL(string: "https://admin-api.playola.fm/v1")!
-
 /// Errors specific to the station player
 public enum StationPlayerError: Error, LocalizedError {
   case networkError(String)
@@ -60,6 +58,7 @@ public enum StationPlayerError: Error, LocalizedError {
 /// ```
 @MainActor
 final public class PlayolaStationPlayer: ObservableObject {
+  var baseUrl = URL(string: "https://admin-api.playola.fm/v1")!
   @Published public var stationId: String?  // TODO: Change this to Station model
   private var interruptedStationId: String?
   var currentSchedule: Schedule?
@@ -110,6 +109,7 @@ final public class PlayolaStationPlayer: ObservableObject {
     self.authProvider = authProvider
     self.listeningSessionReporter = ListeningSessionReporter(
       stationPlayer: self, authProvider: authProvider, baseURL: baseURL)
+    self.baseUrl = baseURL
   }
 
   public enum State: Sendable {

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerTests.swift
@@ -18,6 +18,18 @@ struct PlayolaStationPlayerTests {
     #expect(player.listeningSessionReporter?.baseURL == customBaseURL)
   }
 
+  @Test("Configure updates the player baseUrl")
+  func testConfigureUpdatesPlayerBaseURL() async throws {
+    let customBaseURL = URL(string: "http://localhost:6000/v1")!
+    let mockAuthProvider = MockAuthProvider()
+    let mockFileDownloadManager = MockFileDownloadManager()
+    let player = PlayolaStationPlayer(fileDownloadManager: mockFileDownloadManager)
+
+    player.configure(authProvider: mockAuthProvider, baseURL: customBaseURL)
+
+    #expect(player.baseUrl == customBaseURL)
+  }
+
   @Test("Configure uses default production baseURL when not specified")
   func testConfigureUsesDefaultBaseURL() async throws {
     let mockAuthProvider = MockAuthProvider()


### PR DESCRIPTION
This pull request updates how the `baseUrl` is managed within the `PlayolaStationPlayer` class, making it an instance variable instead of a global constant. It also adds a test to ensure that configuring the player updates its `baseUrl` correctly.

**Refactoring and configuration improvements:**

* Converted the global `baseUrl` constant to an instance variable within `PlayolaStationPlayer`, allowing it to be set per instance and updated via the `configure` method. [[1]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL13-L14) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR61) [[3]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR112)

**Testing enhancements:**

* Added a unit test `testConfigureUpdatesPlayerBaseURL` to verify that calling `configure` updates the player's `baseUrl` as expected.