### PR TITLE
Fix Missing /v1

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -400,7 +400,7 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   private func createScheduleURL(for stationId: String) -> URL {
-    return baseUrl.appending(path: "/stations/\(stationId)/schedule")
+    return baseUrl.appending(path: "/v1/stations/\(stationId)/schedule")
       .appending(queryItems: [URLQueryItem(name: "includeRelatedTexts", value: "true")])
   }
 


### PR DESCRIPTION
This pull request updates the API endpoint used to fetch a station's schedule in the `PlayolaStationPlayer` class to use the versioned `/v1` path. This ensures the app targets the correct version of the backend API.

- API endpoint update:
  * Changed the schedule URL in `PlayolaStationPlayer.swift` to use `/v1/stations/{stationId}/schedule` instead of `/stations/{stationId}/schedule`, ensuring requests go to the versioned API.