### PR TITLE
Stations - Release Date

### DIFF
--- a/Sources/PlayolaPlayer/Models/Station.swift
+++ b/Sources/PlayolaPlayer/Models/Station.swift
@@ -13,14 +13,23 @@ public struct Station: Codable, Sendable {
   public let imageUrl: URL?
   public let description: String
   public let active: Bool?
+  public let releaseDate: Date?
   public let createdAt: Date
   public let updatedAt: Date
 
   // Custom coding keys to handle the imageUrl conversion
   private enum CodingKeys: String, CodingKey {
-    case id, name, curatorName, description, active, createdAt, updatedAt
+    case id, name, curatorName, description, active, releaseDate, createdAt, updatedAt
     case imageUrlString = "imageUrl"
   }
+  private static let releaseDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -30,6 +39,17 @@ public struct Station: Codable, Sendable {
     curatorName = try container.decode(String.self, forKey: .curatorName)
     description = try container.decode(String.self, forKey: .description)
     active = try container.decodeIfPresent(Bool.self, forKey: .active)
+    if let releaseDateString = try container.decodeIfPresent(String.self, forKey: .releaseDate) {
+      if let parsed = DateFormatter.iso8601Full.date(from: releaseDateString) {
+        releaseDate = parsed
+      } else if let dateOnly = Station.releaseDateFormatter.date(from: releaseDateString) {
+        releaseDate = dateOnly
+      } else {
+        releaseDate = nil
+      }
+    } else {
+      releaseDate = nil
+    }
     createdAt = try container.decode(Date.self, forKey: .createdAt)
     updatedAt = try container.decode(Date.self, forKey: .updatedAt)
 
@@ -49,6 +69,10 @@ public struct Station: Codable, Sendable {
     try container.encode(curatorName, forKey: .curatorName)
     try container.encode(description, forKey: .description)
     try container.encodeIfPresent(active, forKey: .active)
+    if let releaseDate {
+      let encodedDate = DateFormatter.iso8601Full.string(from: releaseDate)
+      try container.encode(encodedDate, forKey: .releaseDate)
+    }
     try container.encode(createdAt, forKey: .createdAt)
     try container.encode(updatedAt, forKey: .updatedAt)
 
@@ -59,7 +83,7 @@ public struct Station: Codable, Sendable {
   // Original initializer updated to convert String to URL
   public init(
     id: String, name: String, curatorName: String, imageUrl: String?, description: String,
-    active: Bool? = nil, createdAt: Date, updatedAt: Date
+    active: Bool? = nil, releaseDate: Date? = nil, createdAt: Date, updatedAt: Date
   ) {
     self.id = id
     self.name = name
@@ -67,6 +91,7 @@ public struct Station: Codable, Sendable {
     self.imageUrl = imageUrl != nil ? URL(string: imageUrl!) : nil
     self.description = description
     self.active = active
+    self.releaseDate = releaseDate
     self.createdAt = createdAt
     self.updatedAt = updatedAt
   }
@@ -74,7 +99,7 @@ public struct Station: Codable, Sendable {
   // New convenience initializer that accepts URL directly
   public init(
     id: String, name: String, curatorName: String, imageUrl: URL?, description: String,
-    active: Bool? = nil, createdAt: Date, updatedAt: Date
+    active: Bool? = nil, releaseDate: Date? = nil, createdAt: Date, updatedAt: Date
   ) {
     self.id = id
     self.name = name
@@ -82,6 +107,7 @@ public struct Station: Codable, Sendable {
     self.imageUrl = imageUrl
     self.description = description
     self.active = active
+    self.releaseDate = releaseDate
     self.createdAt = createdAt
     self.updatedAt = updatedAt
   }


### PR DESCRIPTION
This pull request adds support for a new `releaseDate` property to the `Station` model in `Station.swift`. The changes ensure that `releaseDate` is properly handled during encoding, decoding, and initialization, with flexible date parsing for both ISO8601 and date-only formats.

**Release date support:**

* Added a new optional `releaseDate` property to the `Station` struct, updated coding keys, and provided a custom date formatter for parsing date-only strings.
* Updated the decoding logic to parse `releaseDate` from either ISO8601 or "yyyy-MM-dd" formatted strings, making the model more robust to different date formats.
* Modified the encoding logic to serialize `releaseDate` using the ISO8601 format when present.

**Initializer updates:**

* Updated both initializers for `Station` to accept the new `releaseDate` property, ensuring it is set correctly when creating instances.