### PR TITLE
Adjust Playback For "Live" Broadcasting

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -334,70 +334,67 @@ final public class PlayolaStationPlayer: ObservableObject {
   private func scheduleUpcomingSpins() async {
     guard let stationId else {
       let error = StationPlayerError.invalidStationId("No station ID available")
-      Task {
-        await errorReporter.reportError(error, level: .warning)
-      }
+      Task { await errorReporter.reportError(error, level: .warning) }
       return
     }
 
     while !Task.isCancelled {
       do {
-        let updatedSchedule = try await getUpdatedSchedule(stationId: stationId)
-
-        os_log(
-          "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
-          updatedSchedule.spins.count,
-          updatedSchedule.current(offsetTimeInterval: scheduleOffset).count)
-
-        // Server returns only locked-in spins via lockedIn=true param.
-        // This filter is a client-side safety net to prevent scheduling spins too far out.
-        let spinsToLoad = updatedSchedule.current(offsetTimeInterval: scheduleOffset).filter {
-          $0.airtime < .now + TimeInterval(600)
-        }
-
-        os_log(
-          "Loading %d upcoming spins", log: PlayolaStationPlayer.logger, type: .info,
-          spinsToLoad.count)
-
-        for spin in spinsToLoad {
-          try Task.checkCancellation()
-
-          if !isScheduled(spin: spin) {
-            os_log(
-              "Scheduling new spin: %@ at %@", log: PlayolaStationPlayer.logger, type: .info,
-              spin.id,
-              ISO8601DateFormatter().string(from: spin.airtime))
-            try await scheduleSpin(spin: spin)
-          }
-        }
-
-        let scheduledSpinsCount = _spinPlayers.filter { $0.spin != nil }.count
-        os_log(
-          "Total scheduled spins: %d", log: PlayolaStationPlayer.logger, type: .info,
-          scheduledSpinsCount)
-
+        try await performScheduleUpdate(stationId: stationId)
+      } catch is CancellationError {
+        os_log("📛 Schedule update cancelled", log: PlayolaStationPlayer.logger, type: .info)
+        return
       } catch {
-        if error is CancellationError {
-          os_log("📛 Schedule update cancelled", log: PlayolaStationPlayer.logger, type: .info)
-          return
-        } else {
-          Task {
-            await errorReporter.reportError(
-              error, context: "Failed to schedule upcoming spins", level: .error)
-          }
-          os_log(
-            "Schedule update failed: %@", log: PlayolaStationPlayer.logger, type: .error,
-            error.localizedDescription)
+        Task {
+          await errorReporter.reportError(
+            error, context: "Failed to schedule upcoming spins", level: .error)
         }
+        os_log(
+          "Schedule update failed: %@", log: PlayolaStationPlayer.logger, type: .error,
+          error.localizedDescription)
       }
 
-      // Wait before next poll
       do {
         try await Task.sleep(nanoseconds: schedulePollingInterval)
       } catch {
-        return  // Task was cancelled during sleep
+        return
       }
     }
+  }
+
+  @MainActor
+  private func performScheduleUpdate(stationId: String) async throws {
+    let updatedSchedule = try await getUpdatedSchedule(stationId: stationId)
+
+    os_log(
+      "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
+      updatedSchedule.spins.count,
+      updatedSchedule.current(offsetTimeInterval: scheduleOffset).count)
+
+    // Server returns only locked-in spins via lockedIn=true param.
+    // This filter is a client-side safety net to prevent scheduling spins too far out.
+    let spinsToLoad = updatedSchedule.current(offsetTimeInterval: scheduleOffset).filter {
+      $0.airtime < .now + TimeInterval(600)
+    }
+
+    os_log(
+      "Loading %d upcoming spins", log: PlayolaStationPlayer.logger, type: .info,
+      spinsToLoad.count)
+
+    for spin in spinsToLoad {
+      try Task.checkCancellation()
+      if !isScheduled(spin: spin) {
+        os_log(
+          "Scheduling new spin: %@ at %@", log: PlayolaStationPlayer.logger, type: .info,
+          spin.id, ISO8601DateFormatter().string(from: spin.airtime))
+        try await scheduleSpin(spin: spin)
+      }
+    }
+
+    let scheduledSpinsCount = _spinPlayers.filter { $0.spin != nil }.count
+    os_log(
+      "Total scheduled spins: %d", log: PlayolaStationPlayer.logger, type: .info,
+      scheduledSpinsCount)
   }
 
   private func getUpdatedSchedule(stationId: String) async throws -> Schedule {

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -328,6 +328,8 @@ final public class PlayolaStationPlayer: ObservableObject {
     return _spinPlayers.contains { $0.spin?.id == spin.id }
   }
 
+  private let schedulePollingInterval: UInt64 = 20_000_000_000  // 20 seconds in nanoseconds
+
   @MainActor
   private func scheduleUpcomingSpins() async {
     guard let stationId else {
@@ -338,59 +340,62 @@ final public class PlayolaStationPlayer: ObservableObject {
       return
     }
 
-    do {
-      // Check if task is cancelled before proceeding
-      try Task.checkCancellation()
+    while !Task.isCancelled {
+      do {
+        let updatedSchedule = try await getUpdatedSchedule(stationId: stationId)
 
-      let updatedSchedule = try await getUpdatedSchedule(stationId: stationId)
-
-      // Log how many spins are in the updated schedule
-      os_log(
-        "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
-        updatedSchedule.spins.count,
-        updatedSchedule.current(offsetTimeInterval: scheduleOffset).count)
-
-      // Extend the time window to load more upcoming spins (10 minutes instead of 6)
-      let spinsToLoad = updatedSchedule.current(offsetTimeInterval: scheduleOffset).filter {
-        $0.airtime < .now + TimeInterval(600)
-      }
-
-      os_log(
-        "Loading %d upcoming spins", log: PlayolaStationPlayer.logger, type: .info,
-        spinsToLoad.count)
-
-      for spin in spinsToLoad {
-        // Check cancellation before each spin
-        try Task.checkCancellation()
-
-        if !isScheduled(spin: spin) {
-          os_log(
-            "Scheduling new spin: %@ at %@", log: PlayolaStationPlayer.logger, type: .info, spin.id,
-            ISO8601DateFormatter().string(from: spin.airtime))
-          try await scheduleSpin(spin: spin)
-        }
-      }
-
-      // Log already scheduled spins
-      let scheduledSpinsCount = _spinPlayers.filter { $0.spin != nil }.count
-      os_log(
-        "Total scheduled spins: %d", log: PlayolaStationPlayer.logger, type: .info,
-        scheduledSpinsCount)
-
-    } catch {
-      // Check if this was a cancellation
-      if error is CancellationError {
-        os_log("📛 Schedule update cancelled", log: PlayolaStationPlayer.logger, type: .info)
-      } else {
-        Task {
-          await errorReporter.reportError(
-            error, context: "Failed to schedule upcoming spins", level: .error)
-        }
-
-        // Log more details about the error
         os_log(
-          "Schedule update failed: %@", log: PlayolaStationPlayer.logger, type: .error,
-          error.localizedDescription)
+          "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
+          updatedSchedule.spins.count,
+          updatedSchedule.current(offsetTimeInterval: scheduleOffset).count)
+
+        // Server returns only locked-in spins via lockedIn=true param.
+        // This filter is a client-side safety net to prevent scheduling spins too far out.
+        let spinsToLoad = updatedSchedule.current(offsetTimeInterval: scheduleOffset).filter {
+          $0.airtime < .now + TimeInterval(600)
+        }
+
+        os_log(
+          "Loading %d upcoming spins", log: PlayolaStationPlayer.logger, type: .info,
+          spinsToLoad.count)
+
+        for spin in spinsToLoad {
+          try Task.checkCancellation()
+
+          if !isScheduled(spin: spin) {
+            os_log(
+              "Scheduling new spin: %@ at %@", log: PlayolaStationPlayer.logger, type: .info,
+              spin.id,
+              ISO8601DateFormatter().string(from: spin.airtime))
+            try await scheduleSpin(spin: spin)
+          }
+        }
+
+        let scheduledSpinsCount = _spinPlayers.filter { $0.spin != nil }.count
+        os_log(
+          "Total scheduled spins: %d", log: PlayolaStationPlayer.logger, type: .info,
+          scheduledSpinsCount)
+
+      } catch {
+        if error is CancellationError {
+          os_log("📛 Schedule update cancelled", log: PlayolaStationPlayer.logger, type: .info)
+          return
+        } else {
+          Task {
+            await errorReporter.reportError(
+              error, context: "Failed to schedule upcoming spins", level: .error)
+          }
+          os_log(
+            "Schedule update failed: %@", log: PlayolaStationPlayer.logger, type: .error,
+            error.localizedDescription)
+        }
+      }
+
+      // Wait before next poll
+      do {
+        try await Task.sleep(nanoseconds: schedulePollingInterval)
+      } catch {
+        return  // Task was cancelled during sleep
       }
     }
   }
@@ -412,7 +417,10 @@ final public class PlayolaStationPlayer: ObservableObject {
 
   private func createScheduleURL(for stationId: String) -> URL {
     return baseUrl.appending(path: "/v1/stations/\(stationId)/schedule")
-      .appending(queryItems: [URLQueryItem(name: "includeRelatedTexts", value: "true")])
+      .appending(queryItems: [
+        URLQueryItem(name: "includeRelatedTexts", value: "true"),
+        URLQueryItem(name: "lockedIn", value: "true"),
+      ])
   }
 
   private func validateHTTPResponse(_ response: URLResponse, url: URL) throws -> HTTPURLResponse {


### PR DESCRIPTION
This pull request updates the `PlayolaStationPlayer` to improve how upcoming spins are scheduled and polled from the server. The changes introduce a polling loop with a fixed interval, ensure only "locked-in" spins are scheduled, and enhance error handling and cancellation logic.

**Polling and Scheduling Improvements:**

* Added a polling loop in `scheduleUpcomingSpins` to repeatedly fetch and schedule upcoming spins every 20 seconds, using a new `schedulePollingInterval` constant. [[1]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR331-R332) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR343-R353) [[3]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL363-R400)
* Updated the schedule fetch URL to include the `lockedIn=true` parameter, ensuring only locked-in spins are retrieved from the server.

**Error Handling and Cancellation:**

* Improved cancellation logic so that the polling loop exits cleanly if the task is cancelled, including during sleep intervals.
* Enhanced error reporting by logging and reporting errors with additional context, and ensuring proper handling of cancellation errors.

**Other Adjustments:**

* Extended the time window for scheduling upcoming spins from 6 to 10 minutes as a client-side safety measure.