### PR TITLE
Bugfix: Carplay Can't Play Sometimes

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -536,6 +536,12 @@ final public class PlayolaStationPlayer: ObservableObject {
   ///   - Missing audio content in the schedule
   ///   - File download failures
   public func play(stationId: String, atDate: Date? = nil) async throws {
+    // Reset any stale interruption state when explicitly starting playback.
+    // This ensures CarPlay and other external callers always get a clean start.
+    isSuspended = false
+    wasPlayingBeforeInterruption = false
+    interruptedStationId = nil
+
     // Cancel any existing play task
     playTask?.cancel()
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `PlayolaStationPlayer` class to improve playback reliability, especially when playback is started externally (e.g., via CarPlay). Now, when playback is explicitly started using the `play` method, any stale interruption-related state is reset to ensure a clean start.

- Playback state management:
  * In `PlayolaStationPlayer.swift`, the `play` method now resets `isSuspended`, `wasPlayingBeforeInterruption`, and `interruptedStationId` before starting playback, preventing stale interruption state from affecting new playback sessions.