### PR TITLE
Bugfix: Audio Grabbed Back from Interruptors

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -692,6 +692,10 @@ final public class PlayolaStationPlayer: ObservableObject {
         wasPlayingBeforeInterruption = isPlaying
         interruptedStationId = stationId
 
+        // Cancel scheduling to prevent grabbing audio back from other apps
+        schedulingTask?.cancel()
+        schedulingTask = nil
+
       case .ended:
         os_log("Audio session interruption ended", log: PlayolaStationPlayer.logger, type: .info)
         isSuspended = false


### PR DESCRIPTION
This pull request introduces a minor but important update to the `PlayolaStationPlayer` class to improve audio session handling during interruptions. Specifically, it ensures that the player does not attempt to resume playback or scheduling when another app takes control of the audio session.

Audio session interruption handling:

* In `PlayolaStationPlayer.swift`, during an audio session interruption, the code now cancels any ongoing scheduling task and sets `schedulingTask` to `nil` to prevent the player from grabbing audio focus back from other apps.