### PR TITLE
Incorporate Models for Shows, Airings, and Episodes

### DIFF
--- a/Sources/PlayolaPlayer/Models/Airing.swift
+++ b/Sources/PlayolaPlayer/Models/Airing.swift
@@ -1,0 +1,72 @@
+//
+//  Airing.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 1/7/26.
+//
+
+import Foundation
+
+/// Represents a scheduled airing of an episode
+public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
+  public let id: String
+  public let episodeId: String
+  public let stationId: String
+  public let airtime: Date
+  public let createdAt: Date
+  public let updatedAt: Date
+  public let episode: Episode?
+
+  public init(
+    id: String,
+    episodeId: String,
+    stationId: String,
+    airtime: Date,
+    createdAt: Date,
+    updatedAt: Date,
+    episode: Episode? = nil
+  ) {
+    self.id = id
+    self.episodeId = episodeId
+    self.stationId = stationId
+    self.airtime = airtime
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.episode = episode
+  }
+}
+
+extension Airing {
+  public static var mock: Airing {
+    Airing(
+      id: "mock-airing-id",
+      episodeId: "mock-episode-id",
+      stationId: "mock-station-id",
+      airtime: Date(timeIntervalSince1970: 1_800_000_000),
+      createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+      episode: .mock
+    )
+  }
+
+  public static func mockWith(
+    id: String? = nil,
+    episodeId: String? = nil,
+    stationId: String? = nil,
+    airtime: Date? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil,
+    episode: Episode?? = nil
+  ) -> Airing {
+    let mock = Self.mock
+    return Airing(
+      id: id ?? mock.id,
+      episodeId: episodeId ?? mock.episodeId,
+      stationId: stationId ?? mock.stationId,
+      airtime: airtime ?? mock.airtime,
+      createdAt: createdAt ?? mock.createdAt,
+      updatedAt: updatedAt ?? mock.updatedAt,
+      episode: episode ?? mock.episode
+    )
+  }
+}

--- a/Sources/PlayolaPlayer/Models/Episode.swift
+++ b/Sources/PlayolaPlayer/Models/Episode.swift
@@ -1,0 +1,72 @@
+//
+//  Episode.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 1/7/26.
+//
+
+import Foundation
+
+/// Represents an episode of a show
+public struct Episode: Codable, Sendable, Equatable, Hashable, Identifiable {
+  public let id: String
+  public let showId: String
+  public let title: String
+  public let durationMS: Int?
+  public let createdAt: Date
+  public let updatedAt: Date
+  public let show: Show?
+
+  public init(
+    id: String,
+    showId: String,
+    title: String,
+    durationMS: Int? = nil,
+    createdAt: Date,
+    updatedAt: Date,
+    show: Show? = nil
+  ) {
+    self.id = id
+    self.showId = showId
+    self.title = title
+    self.durationMS = durationMS
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.show = show
+  }
+}
+
+extension Episode {
+  public static var mock: Episode {
+    Episode(
+      id: "mock-episode-id",
+      showId: "mock-show-id",
+      title: "Mock Episode Title",
+      durationMS: 1000 * 60 * 30,
+      createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+      show: .mock
+    )
+  }
+
+  public static func mockWith(
+    id: String? = nil,
+    showId: String? = nil,
+    title: String? = nil,
+    durationMS: Int?? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil,
+    show: Show?? = nil
+  ) -> Episode {
+    let mock = Self.mock
+    return Episode(
+      id: id ?? mock.id,
+      showId: showId ?? mock.showId,
+      title: title ?? mock.title,
+      durationMS: durationMS ?? mock.durationMS,
+      createdAt: createdAt ?? mock.createdAt,
+      updatedAt: updatedAt ?? mock.updatedAt,
+      show: show ?? mock.show
+    )
+  }
+}

--- a/Sources/PlayolaPlayer/Models/ScheduledShow.swift
+++ b/Sources/PlayolaPlayer/Models/ScheduledShow.swift
@@ -1,0 +1,72 @@
+//
+//  ScheduledShow.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 1/6/26.
+//
+
+import Foundation
+
+/// Represents a scheduled instance of a show
+public struct ScheduledShow: Codable, Sendable, Equatable, Hashable, Identifiable {
+  public let id: String
+  public let showId: String
+  public let stationId: String
+  public let airtime: Date
+  public let createdAt: Date
+  public let updatedAt: Date
+  public let show: Show?
+
+  public init(
+    id: String,
+    showId: String,
+    stationId: String,
+    airtime: Date,
+    createdAt: Date,
+    updatedAt: Date,
+    show: Show?
+  ) {
+    self.id = id
+    self.showId = showId
+    self.stationId = stationId
+    self.airtime = airtime
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.show = show
+  }
+}
+
+extension ScheduledShow {
+  public static var mock: ScheduledShow {
+    ScheduledShow(
+      id: "mock-scheduled-show-id",
+      showId: "mock-show-id",
+      stationId: "mock-station-id",
+      airtime: Date(timeIntervalSince1970: 1_800_000_000),
+      createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+      show: .mock
+    )
+  }
+
+  public static func mockWith(
+    id: String? = nil,
+    showId: String? = nil,
+    stationId: String? = nil,
+    airtime: Date? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil,
+    show: Show? = nil
+  ) -> ScheduledShow {
+    let mock = Self.mock
+    return ScheduledShow(
+      id: id ?? mock.id,
+      showId: showId ?? mock.showId,
+      stationId: stationId ?? mock.stationId,
+      airtime: airtime ?? mock.airtime,
+      createdAt: createdAt ?? mock.createdAt,
+      updatedAt: updatedAt ?? mock.updatedAt,
+      show: show ?? mock.show
+    )
+  }
+}

--- a/Sources/PlayolaPlayer/Models/Show.swift
+++ b/Sources/PlayolaPlayer/Models/Show.swift
@@ -1,0 +1,72 @@
+//
+//  Show.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 1/6/26.
+//
+
+import Foundation
+
+/// Represents a radio show
+public struct Show: Codable, Sendable, Equatable, Hashable, Identifiable {
+  public let id: String
+  public let stationId: String
+  public let title: String
+  public let rrule: String?
+  public let durationMS: Int?
+  public let createdAt: Date
+  public let updatedAt: Date
+
+  public init(
+    id: String,
+    stationId: String,
+    title: String,
+    rrule: String? = nil,
+    durationMS: Int? = nil,
+    createdAt: Date,
+    updatedAt: Date
+  ) {
+    self.id = id
+    self.stationId = stationId
+    self.title = title
+    self.rrule = rrule
+    self.durationMS = durationMS
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+}
+
+extension Show {
+  public static var mock: Show {
+    Show(
+      id: "mock-show-id",
+      stationId: "mock-station-id",
+      title: "Mock Show Title",
+      rrule: nil,
+      durationMS: 1000 * 60 * 30,
+      createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+    )
+  }
+
+  public static func mockWith(
+    id: String? = nil,
+    stationId: String? = nil,
+    title: String? = nil,
+    rrule: String?? = nil,
+    durationMS: Int?? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) -> Show {
+    let mock = Self.mock
+    return Show(
+      id: id ?? mock.id,
+      stationId: stationId ?? mock.stationId,
+      title: title ?? mock.title,
+      rrule: rrule ?? mock.rrule,
+      durationMS: durationMS ?? mock.durationMS,
+      createdAt: createdAt ?? mock.createdAt,
+      updatedAt: updatedAt ?? mock.updatedAt
+    )
+  }
+}

--- a/Sources/PlayolaPlayer/Models/Spin.swift
+++ b/Sources/PlayolaPlayer/Models/Spin.swift
@@ -56,6 +56,9 @@ public struct Spin: Codable, Sendable {
   /// Related texts associated with this spin (e.g., DJ notes, song explanations)
   public let relatedTexts: [RelatedText]?
 
+  /// The airing this spin belongs to (if any)
+  public let airing: Airing?
+
   /// Date provider for testing time-dependent behavior
   public var dateProvider: DateProviderProtocol! = DateProvider()
 
@@ -70,6 +73,7 @@ public struct Spin: Codable, Sendable {
     fades: [Fade],
     spinGroupId: String? = nil,
     relatedTexts: [RelatedText]? = nil,
+    airing: Airing? = nil,
     dateProvider: DateProviderProtocol? = nil
   ) {
     self.id = id
@@ -82,6 +86,7 @@ public struct Spin: Codable, Sendable {
     self.fades = fades.sorted { $0.atMS < $1.atMS }
     self.spinGroupId = spinGroupId
     self.relatedTexts = relatedTexts
+    self.airing = airing
     self.dateProvider = dateProvider ?? DateProvider()
   }
 
@@ -211,7 +216,8 @@ public struct Spin: Codable, Sendable {
       audioBlock: audioBlock,
       fades: fades,
       spinGroupId: spinGroupId,
-      relatedTexts: relatedTexts
+      relatedTexts: relatedTexts,
+      airing: airing
     )
 
     // Preserve the dateProvider
@@ -222,7 +228,7 @@ public struct Spin: Codable, Sendable {
 
   private enum CodingKeys: String, CodingKey {
     case id, stationId, airtime, createdAt, updatedAt, audioBlock, fades, spinGroupId,
-      startingVolume, relatedTexts
+      startingVolume, relatedTexts, airing
   }
 
   // Custom decoder to handle dateProvider
@@ -240,6 +246,7 @@ public struct Spin: Codable, Sendable {
     fades = decodedFades.sorted { $0.atMS < $1.atMS }
     spinGroupId = try container.decodeIfPresent(String.self, forKey: .spinGroupId)
     relatedTexts = try container.decodeIfPresent([RelatedText].self, forKey: .relatedTexts)
+    airing = try container.decodeIfPresent(Airing.self, forKey: .airing)
 
     // Initialize dateProvider with default value
     dateProvider = DateProvider()
@@ -259,6 +266,7 @@ public struct Spin: Codable, Sendable {
     try container.encode(fades, forKey: .fades)
     try container.encodeIfPresent(spinGroupId, forKey: .spinGroupId)
     try container.encodeIfPresent(relatedTexts, forKey: .relatedTexts)
+    try container.encodeIfPresent(airing, forKey: .airing)
   }
 }
 
@@ -282,6 +290,7 @@ extension Spin {
   ///   - createdAt: Optional override for created date
   ///   - updatedAt: Optional override for updated date
   ///   - relatedTexts: Optional override for related texts
+  ///   - airing: Optional override for airing
   ///   - dateProvider: Optional override for date provider
   /// - Returns: A mock Spin with specified overrides
   public static func mockWith(
@@ -295,6 +304,7 @@ extension Spin {
     createdAt: Date? = nil,
     updatedAt: Date? = nil,
     relatedTexts: [RelatedText]? = nil,
+    airing: Airing?? = nil,
     dateProvider: DateProviderProtocol? = nil
   ) -> Spin {
     // Start with the default mock
@@ -311,7 +321,8 @@ extension Spin {
       audioBlock: audioBlock ?? mockSpin.audioBlock,
       fades: fades ?? mockSpin.fades,
       spinGroupId: spinGroupId ?? mockSpin.spinGroupId,
-      relatedTexts: relatedTexts ?? mockSpin.relatedTexts
+      relatedTexts: relatedTexts ?? mockSpin.relatedTexts,
+      airing: airing ?? mockSpin.airing
     )
 
     // Set date provider if specified


### PR DESCRIPTION
This pull request introduces several new models to the `PlayolaPlayer` codebase to represent shows, episodes, scheduled shows, and airings. It also updates the `Spin` model to support an optional reference to an `Airing`, ensuring that spins can be associated with a scheduled airing when relevant. Additionally, mock data generation methods are provided for all new models to facilitate testing.

The most important changes are:

**New Models for Scheduling and Content Structure:**
- Added `Show`, `Episode`, `ScheduledShow`, and `Airing` models to represent radio shows, their episodes, scheduled show instances, and scheduled airings of episodes, respectively. Each model includes fields for identification, relationships, and relevant metadata, along with `mock` and `mockWith` methods for generating test data. [[1]](diffhunk://#diff-5cb6fbd12afac72cb1773ed3d537abb8ffb02029b15368a5f9d688d74876669fR1-R72) [[2]](diffhunk://#diff-a716fc1ed9efee9d169cd4fcffe3312ef3ebe271a0853ba1aab05a9341957f50R1-R72) [[3]](diffhunk://#diff-acc463a21bd67fef4c7716b73d2b72c4551ef928ebc57e2c17aac585ebc1b166R1-R72) [[4]](diffhunk://#diff-357cc17e337f188fc9c9551de401d64089df81b5a52213e20064f5531ba3ec3dR1-R72)

**Enhancements to the `Spin` Model:**
- Updated the `Spin` struct to include an optional `airing` property, allowing each spin to reference a specific airing if applicable. This change is reflected in the struct's properties, initializer, copy method, coding keys, and encoding/decoding logic. [[1]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR59-R61) [[2]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR76) [[3]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR89) [[4]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cL214-R220) [[5]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cL225-R231) [[6]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR249) [[7]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR269)

**Testability Improvements:**
- Extended the `Spin.mockWith` method to allow overriding the associated `airing`, making it easier to generate test spins with specific airings for unit tests. [[1]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR293) [[2]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cR307) [[3]](diffhunk://#diff-8a84bea7a588a34134f9a508cf4364e561f738eb883f5346610a0e5e2454ab3cL314-R325)