### PR TITLE
Add Station to Airing Model

### DIFF
--- a/Sources/PlayolaPlayer/Models/Airing.swift
+++ b/Sources/PlayolaPlayer/Models/Airing.swift
@@ -16,6 +16,7 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
   public let createdAt: Date
   public let updatedAt: Date
   public let episode: Episode?
+  public let station: Station?
 
   public init(
     id: String,
@@ -24,7 +25,8 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
     airtime: Date,
     createdAt: Date,
     updatedAt: Date,
-    episode: Episode? = nil
+    episode: Episode? = nil,
+    station: Station? = nil
   ) {
     self.id = id
     self.episodeId = episodeId
@@ -33,6 +35,7 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
     self.createdAt = createdAt
     self.updatedAt = updatedAt
     self.episode = episode
+    self.station = station
   }
 }
 
@@ -45,7 +48,8 @@ extension Airing {
       airtime: Date(timeIntervalSince1970: 1_800_000_000),
       createdAt: Date(timeIntervalSince1970: 1_800_000_000),
       updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
-      episode: .mock
+      episode: .mock,
+      station: .mock
     )
   }
 
@@ -56,7 +60,8 @@ extension Airing {
     airtime: Date? = nil,
     createdAt: Date? = nil,
     updatedAt: Date? = nil,
-    episode: Episode?? = nil
+    episode: Episode?? = nil,
+    station: Station?? = nil
   ) -> Airing {
     let mock = Self.mock
     return Airing(
@@ -66,7 +71,8 @@ extension Airing {
       airtime: airtime ?? mock.airtime,
       createdAt: createdAt ?? mock.createdAt,
       updatedAt: updatedAt ?? mock.updatedAt,
-      episode: episode ?? mock.episode
+      episode: episode ?? mock.episode,
+      station: station ?? mock.station
     )
   }
 }

--- a/Sources/PlayolaPlayer/Models/Station.swift
+++ b/Sources/PlayolaPlayer/Models/Station.swift
@@ -124,6 +124,20 @@ extension Station: Hashable, Equatable {
 }
 
 extension Station {
+  public static var mock: Station {
+    Station(
+      id: "mock-station-id",
+      name: "Mock Station",
+      curatorName: "Mock Curator",
+      imageUrl: nil as URL?,
+      description: "A mock station for testing",
+      active: true,
+      releaseDate: nil,
+      createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_800_000_000)
+    )
+  }
+
   public static func mockWith(
     id: String = "mock-station-id",
     name: String = "Mock Station",


### PR DESCRIPTION
This pull request adds support for including an associated `Station` in the `Airing` model and updates related mock and factory methods to handle this new property. The changes ensure that `Airing` instances can reference a `Station`, including in tests and mock data.

### Model enhancements

* Added an optional `station` property to the `Airing` struct, allowing each airing to reference a `Station` instance.
* Updated the `Airing` initializer to accept a `station` parameter, defaulting to `nil`. [[1]](diffhunk://#diff-357cc17e337f188fc9c9551de401d64089df81b5a52213e20064f5531ba3ec3dL27-R29) [[2]](diffhunk://#diff-357cc17e337f188fc9c9551de401d64089df81b5a52213e20064f5531ba3ec3dR38)

### Mock and factory method updates

* Modified the `Airing.mock` static property to include a mock `Station` instance.
* Updated the `Airing.mockWith` factory method to accept and handle an optional `station` parameter, defaulting to the mock station if not provided. [[1]](diffhunk://#diff-357cc17e337f188fc9c9551de401d64089df81b5a52213e20064f5531ba3ec3dL59-R64) [[2]](diffhunk://#diff-357cc17e337f188fc9c9551de401d64089df81b5a52213e20064f5531ba3ec3dL69-R75)
* Added a static `mock` property to the `Station` struct for convenient creation of mock station instances.