### PR TITLE
Bugfix - ListeningSessionReporter Memory Leak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ orbs:
 jobs:
   swiftlint_check:
     macos:
-      xcode: 16.2.0
+      xcode: 16.4
+    resource_class: m4pro.medium
     steps:
       - checkout
       - run:
@@ -27,7 +28,8 @@ jobs:
 
   test:
     macos:
-      xcode: 16.2.0
+      xcode: 16.4
+    resource_class: m4pro.medium
     environment:
       FASTLANE_SKIP_UPDATE_CHECK: true
       FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 10

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -74,7 +74,8 @@ public class ListeningSessionReporter {
     self.urlSession = urlSession
     self.baseURL = baseURL
 
-    stationPlayer.$stationId.sink { stationId in
+    stationPlayer.$stationId.sink { [weak self] stationId in
+      guard let self else { return }
       if let stationId {
         Task {
           do {


### PR DESCRIPTION
This pull request makes a small but important improvement to the `ListeningSessionReporter` class. The change ensures that the closure observing `stationPlayer.$stationId` does not cause a retain cycle by capturing `self` weakly. This helps prevent potential memory leaks.