### PR TITLE
Remove Basic Auth

### DIFF
--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -51,7 +51,6 @@ public class ListeningSessionReporter {
     return DeviceInfoProvider.identifierForVendor?.uuidString
   }
   var timer: Timer?
-  let basicToken = "aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx"  // TODO: De-hard-code this
   var currentSessionStationId: String?
   var disposeBag = Set<AnyCancellable>()
   weak var stationPlayer: PlayolaStationPlayer?
@@ -239,17 +238,15 @@ public class ListeningSessionReporter {
 
     // Check if we've exceeded retry limits
     if refreshAttempts >= maxRefreshAttempts {
+      let error = ListeningSessionError.authenticationFailed("Max refresh attempts exceeded")
       Task {
         await errorReporter.reportError(
-          ListeningSessionError.authenticationFailed("Max refresh attempts exceeded"),
+          error,
           context: "Exceeded maximum refresh attempts (\(maxRefreshAttempts))",
           level: .warning
         )
       }
-
-      // Fall back to Basic auth
-      try await attemptWithBasicAuth(url: url, requestBody: requestBody)
-      return
+      throw error
     }
 
     // Attempt token refresh
@@ -276,43 +273,7 @@ public class ListeningSessionReporter {
           "HTTP status code after refresh: \(retryHttpResponse.statusCode)")
       }
     } else {
-      // Refresh failed - try with Basic auth as fallback
-      try await attemptWithBasicAuth(url: url, requestBody: requestBody)
-    }
-  }
-
-  private func attemptWithBasicAuth(url: URL, requestBody: ListeningSessionRequest) async throws {
-    // Create request with Basic auth (bypassing the auth provider)
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-
-    do {
-      request.httpBody = try JSONEncoder().encode(requestBody)
-    } catch {
-      throw ListeningSessionError.encodingError(
-        "Failed to encode request body: \(error.localizedDescription)")
-    }
-
-    request.addValue("Basic \(basicToken)", forHTTPHeaderField: "Authorization")
-    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-    let (_, response) = try await urlSession.data(for: request)
-
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw ListeningSessionError.invalidResponse("Invalid HTTP response with Basic auth")
-    }
-
-    if (200...299).contains(httpResponse.statusCode) {
-      // Success with Basic auth
-      Task {
-        await errorReporter.reportError(
-          ListeningSessionError.authenticationFailed("Fell back to Basic auth"),
-          context: "Authentication failed, using Basic auth fallback",
-          level: .warning
-        )
-      }
-    } else {
-      throw ListeningSessionError.authenticationFailed("Both Bearer token and Basic auth failed")
+      throw ListeningSessionError.authenticationFailed("Token refresh failed")
     }
   }
 
@@ -333,12 +294,10 @@ public class ListeningSessionReporter {
         "Failed to encode request body: \(error.localizedDescription)")
     }
 
-    // Use Bearer token if user is authenticated, otherwise fall back to Basic auth
-    if let userToken = await authProvider?.getCurrentToken() {
-      request.addValue("Bearer \(userToken)", forHTTPHeaderField: "Authorization")
-    } else {
-      request.addValue("Basic \(basicToken)", forHTTPHeaderField: "Authorization")
+    guard let userToken = await authProvider?.getCurrentToken() else {
+      throw ListeningSessionError.authenticationFailed("No authentication token available")
     }
+    request.addValue("Bearer \(userToken)", forHTTPHeaderField: "Authorization")
 
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     return request

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -30,33 +30,29 @@ struct ListeningSessionTests {
       #expect(authHeader == "Bearer valid.jwt.token")
     }
 
-    @Test("Uses Basic auth when no token available")
-    func testUsesBasicAuthWhenNoToken() async throws {
+    @Test("Throws when no token available")
+    func testThrowsWhenNoToken() async throws {
       let mockAuth = MockAuthProvider(currentToken: nil)
       let reporter = await ListeningSessionReporter(authProvider: mockAuth)
 
       let requestBody = ["test": "data"]
       let url = URL(string: "https://test.com")!
 
-      let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
-
-      // Check that Authorization header contains Basic auth
-      let authHeader = request.value(forHTTPHeaderField: "Authorization")
-      #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
+      await #expect(throws: ListeningSessionError.self) {
+        _ = try await reporter.createPostRequest(url: url, requestBody: requestBody)
+      }
     }
 
-    @Test("Uses Basic auth when auth provider is nil")
-    func testUsesBasicAuthWhenProviderIsNil() async throws {
+    @Test("Throws when auth provider is nil")
+    func testThrowsWhenProviderIsNil() async throws {
       let reporter = await ListeningSessionReporter(authProvider: nil)
 
       let requestBody = ["test": "data"]
       let url = URL(string: "https://test.com")!
 
-      let request = try await reporter.createPostRequest(url: url, requestBody: requestBody)
-
-      // Check that Authorization header contains Basic auth
-      let authHeader = request.value(forHTTPHeaderField: "Authorization")
-      #expect(authHeader == "Basic aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx")
+      await #expect(throws: ListeningSessionError.self) {
+        _ = try await reporter.createPostRequest(url: url, requestBody: requestBody)
+      }
     }
   }
 
@@ -90,8 +86,8 @@ struct ListeningSessionTests {
       #expect(mockURLSession.requestCallCount == 2)
     }
 
-    @Test("Handles failed token refresh gracefully")
-    func testHandlesFailedRefresh() async throws {
+    @Test("Throws when token refresh fails")
+    func testThrowsWhenRefreshFails() async throws {
       let mockAuth = MockAuthProvider(
         currentToken: "expired.token",
         refreshedToken: nil  // Refresh fails
@@ -102,24 +98,22 @@ struct ListeningSessionTests {
       let testURL = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
       mockURLSession.addResponse(statusCode: 401, url: testURL)
 
-      // Basic auth fallback returns 200
-      mockURLSession.addResponse(statusCode: 200, url: testURL)
-
       let reporter = await ListeningSessionReporter(
         authProvider: mockAuth, urlSession: mockURLSession)
 
-      // This should fall back to Basic auth
-      try await reporter.reportOrExtendListeningSession("test-station-id")
+      await #expect(throws: ListeningSessionError.self) {
+        try await reporter.reportOrExtendListeningSession("test-station-id")
+      }
 
-      // Verify that refresh was called
+      // Verify that refresh was attempted
       #expect(mockAuth.refreshCallCount == 1)
 
-      // Verify that two HTTP requests were made (initial + Basic auth fallback)
-      #expect(mockURLSession.requestCallCount == 2)
+      // Verify only the initial request was made (no fallback)
+      #expect(mockURLSession.requestCallCount == 1)
     }
 
-    @Test("Exceeds max refresh attempts and falls back to Basic auth")
-    func testExceedsMaxRefreshAttempts() async throws {
+    @Test("Throws after exceeding max refresh attempts")
+    func testThrowsAfterMaxRefreshAttempts() async throws {
       let mockAuth = MockAuthProvider(
         currentToken: "expired.token",
         refreshedToken: "still.expired.token"  // Refresh returns token but still gets 401
@@ -136,21 +130,19 @@ struct ListeningSessionTests {
         mockURLSession.addResponse(statusCode: 401, url: testURL)
       }
 
-      // Final Basic auth fallback returns 200
-      mockURLSession.addResponse(statusCode: 200, url: testURL)
-
       let reporter = await ListeningSessionReporter(
         authProvider: mockAuth, urlSession: mockURLSession)
 
-      // This should exhaust refresh attempts and fall back to Basic auth
-      try await reporter.reportOrExtendListeningSession("test-station-id")
+      await #expect(throws: ListeningSessionError.self) {
+        try await reporter.reportOrExtendListeningSession("test-station-id")
+      }
 
       // Verify that refresh was called 3 times (max attempts)
       #expect(mockAuth.refreshCallCount == 3)
 
       // Verify correct number of HTTP requests:
-      // 1 initial + 3 refresh attempts + 1 Basic auth fallback = 5
-      #expect(mockURLSession.requestCallCount == 5)
+      // 1 initial + 3 refresh attempts = 4 (no fallback)
+      #expect(mockURLSession.requestCallCount == 4)
     }
 
     @Test("Resets retry counter after successful request")
@@ -216,7 +208,7 @@ struct ListeningSessionTests {
     func testUsesCustomBaseURL() async throws {
       let customBaseURL = URL(string: "http://localhost:3000")!
       let mockSession = MockURLSession()
-      let mockAuth = MockAuthProvider()
+      let mockAuth = MockAuthProvider(currentToken: "test.token")
 
       let reporter = await ListeningSessionReporter(
         authProvider: mockAuth,
@@ -237,7 +229,7 @@ struct ListeningSessionTests {
     @Test("Uses default production URL when not specified")
     func testUsesDefaultProductionURL() async throws {
       let mockSession = MockURLSession()
-      let mockAuth = MockAuthProvider()
+      let mockAuth = MockAuthProvider(currentToken: "test.token")
 
       let reporter = await ListeningSessionReporter(
         authProvider: mockAuth,
@@ -258,7 +250,7 @@ struct ListeningSessionTests {
     func testEndSessionUsesCustomBaseURL() async throws {
       let customBaseURL = URL(string: "http://localhost:8080")!
       let mockSession = MockURLSession()
-      let mockAuth = MockAuthProvider()
+      let mockAuth = MockAuthProvider(currentToken: "test.token")
 
       let reporter = await ListeningSessionReporter(
         authProvider: mockAuth,


### PR DESCRIPTION
This pull request updates the authentication flow in `ListeningSessionReporter` to remove the fallback to Basic authentication, enforcing Bearer token usage and improving error handling. The related tests have also been updated to reflect this stricter authentication requirement and to verify that errors are thrown when no valid token is available. These changes help ensure that only authenticated users can report or extend listening sessions, improving security and reliability.

**Authentication flow changes:**

* Removed the fallback to Basic authentication when Bearer token acquisition fails; the code now throws a `ListeningSessionError` if no token is available or if token refresh fails. (`ListeningSessionReporter.swift`) [[1]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013R241-R249) [[2]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L279-R276) [[3]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L336-R300)
* The hardcoded Basic token and related methods have been removed from the implementation, further enforcing exclusive Bearer token usage. (`ListeningSessionReporter.swift`)

**Test updates:**

* Updated tests to expect errors when no authentication token is available or when the auth provider is nil, instead of checking for Basic auth fallback. (`ListeningSessionTests.swift`)
* Modified tests to verify that errors are thrown when token refresh fails or when maximum refresh attempts are exceeded, and that no fallback requests are made. (`ListeningSessionTests.swift`) [[1]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L93-R90) [[2]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L105-R116) [[3]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L139-R145)
* Updated mock authentication providers in tests to always provide a Bearer token for cases where authentication is expected to succeed. (`ListeningSessionTests.swift`) [[1]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L219-R211) [[2]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L240-R232) [[3]](diffhunk://#diff-3038b8685b09f64610e87ffe81971a1d7e96363394a8d90270d2c19da2c6b832L261-R253)