### PR TITLE
Fix audio interruption resume

### DIFF
--- a/Sources/PlayolaPlayer/Player/Streaming/StreamingStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/Streaming/StreamingStationPlayer.swift
@@ -56,6 +56,7 @@ final public class StreamingStationPlayer: ObservableObject {
   private var authProvider: PlayolaAuthenticationProvider?
   private let playerFactory: () -> AVPlayerProviding
   private let audioSessionManager = AudioSessionManager()
+  // internal for testability
   var scheduleFetcher: (String, URL) async throws -> Schedule = { stationId, baseUrl in
     try await ScheduleService.getSchedule(stationId: stationId, baseUrl: baseUrl)
   }
@@ -67,7 +68,7 @@ final public class StreamingStationPlayer: ObservableObject {
   private var scheduleOffset: TimeInterval?
   private var schedulingTask: Task<Void, Never>?
 
-  // Audio interruption state
+  // Audio interruption state (internal for testability)
   var wasPlayingBeforeInterruption = false
   var interruptedStationId: String?
 
@@ -317,6 +318,7 @@ final public class StreamingStationPlayer: ObservableObject {
     }
   #endif
 
+  // internal for testability
   func handleInterruptionBegan() {
     wasPlayingBeforeInterruption = isPlaying
     interruptedStationId = stationId
@@ -324,12 +326,14 @@ final public class StreamingStationPlayer: ObservableObject {
     schedulingTask = nil
   }
 
+  // internal for testability
   func handleInterruptionEnded(shouldResume: Bool) {
     if shouldResume && wasPlayingBeforeInterruption {
       resumeAfterInterruption()
     }
   }
 
+  // internal for testability
   func resumeAfterInterruption() {
     guard let stationToResume = interruptedStationId else { return }
 

--- a/Sources/PlayolaPlayer/Player/Streaming/StreamingStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/Streaming/StreamingStationPlayer.swift
@@ -56,6 +56,9 @@ final public class StreamingStationPlayer: ObservableObject {
   private var authProvider: PlayolaAuthenticationProvider?
   private let playerFactory: () -> AVPlayerProviding
   private let audioSessionManager = AudioSessionManager()
+  var scheduleFetcher: (String, URL) async throws -> Schedule = { stationId, baseUrl in
+    try await ScheduleService.getSchedule(stationId: stationId, baseUrl: baseUrl)
+  }
 
   // MARK: - Internal State
 
@@ -65,9 +68,8 @@ final public class StreamingStationPlayer: ObservableObject {
   private var schedulingTask: Task<Void, Never>?
 
   // Audio interruption state
-  private var isSuspended = false
-  private var wasPlayingBeforeInterruption = false
-  private var interruptedStationId: String?
+  var wasPlayingBeforeInterruption = false
+  var interruptedStationId: String?
 
   // MARK: - Lifecycle
 
@@ -116,19 +118,22 @@ final public class StreamingStationPlayer: ObservableObject {
 
   /// Begins streaming playback of the specified station.
   public func play(stationId: String, atDate: Date? = nil) async throws {
-    isSuspended = false
     wasPlayingBeforeInterruption = false
     interruptedStationId = nil
 
     schedulingTask?.cancel()
+
+    for (_, player) in spinPlayers {
+      player.stop()
+    }
+    spinPlayers.removeAll()
     self.scheduleOffset = atDate?.timeIntervalSinceNow
     self.stationId = stationId
     self.state = .loading
 
     try await audioSessionManager.activate()
 
-    let schedule = try await ScheduleService.getSchedule(
-      stationId: stationId, baseUrl: baseUrl)
+    let schedule = try await scheduleFetcher(stationId, baseUrl)
     self.currentSchedule = schedule
 
     let currentSpins = schedule.current(offsetTimeInterval: scheduleOffset)
@@ -240,8 +245,7 @@ final public class StreamingStationPlayer: ObservableObject {
   }
 
   private func performScheduleUpdate(stationId: String) async throws {
-    let updatedSchedule = try await ScheduleService.getSchedule(
-      stationId: stationId, baseUrl: baseUrl)
+    let updatedSchedule = try await scheduleFetcher(stationId, baseUrl)
 
     let spinsToLoad = updatedSchedule.current(offsetTimeInterval: scheduleOffset).filter {
       $0.airtime < .now + StreamingStationPlayer.scheduleWindow
@@ -283,8 +287,6 @@ final public class StreamingStationPlayer: ObservableObject {
         }
 
         if wasUsingHeadphones && isPlaying {
-          interruptedStationId = stationId
-          wasPlayingBeforeInterruption = true
           stop()
         }
       default:
@@ -300,48 +302,54 @@ final public class StreamingStationPlayer: ObservableObject {
 
       switch type {
       case .began:
-        isSuspended = true
-        wasPlayingBeforeInterruption = isPlaying
-        interruptedStationId = stationId
-        schedulingTask?.cancel()
-        schedulingTask = nil
+        handleInterruptionBegan()
 
       case .ended:
-        isSuspended = false
         guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
           return
         }
         let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
-        if options.contains(.shouldResume) && wasPlayingBeforeInterruption {
-          resumeAfterInterruption()
-        }
+        handleInterruptionEnded(shouldResume: options.contains(.shouldResume))
 
       @unknown default:
         break
       }
     }
-
-    private func resumeAfterInterruption() {
-      guard let stationToResume = interruptedStationId else { return }
-
-      Task { @MainActor in
-        do {
-          try await self.audioSessionManager.activate()
-          try await self.play(stationId: stationToResume)
-        } catch {
-          os_log(
-            "Failed to resume after interruption: %@",
-            log: StreamingStationPlayer.logger, type: .error,
-            error.localizedDescription)
-          await errorReporter.reportError(
-            error, context: "Failed to resume playback after interruption", level: .error)
-        }
-
-        self.interruptedStationId = nil
-        self.wasPlayingBeforeInterruption = false
-      }
-    }
   #endif
+
+  func handleInterruptionBegan() {
+    wasPlayingBeforeInterruption = isPlaying
+    interruptedStationId = stationId
+    schedulingTask?.cancel()
+    schedulingTask = nil
+  }
+
+  func handleInterruptionEnded(shouldResume: Bool) {
+    if shouldResume && wasPlayingBeforeInterruption {
+      resumeAfterInterruption()
+    }
+  }
+
+  func resumeAfterInterruption() {
+    guard let stationToResume = interruptedStationId else { return }
+
+    Task { @MainActor in
+      do {
+        try await self.audioSessionManager.activate()
+        try await self.play(stationId: stationToResume)
+      } catch {
+        os_log(
+          "Failed to resume after interruption: %@",
+          log: StreamingStationPlayer.logger, type: .error,
+          error.localizedDescription)
+        await errorReporter.reportError(
+          error, context: "Failed to resume playback after interruption", level: .error)
+      }
+
+      self.interruptedStationId = nil
+      self.wasPlayingBeforeInterruption = false
+    }
+  }
 }
 
 // MARK: - StreamingSpinPlayerDelegate

--- a/Tests/PlayolaPlayerTests/StreamingStationPlayerTests.swift
+++ b/Tests/PlayolaPlayerTests/StreamingStationPlayerTests.swift
@@ -35,6 +35,17 @@ struct StreamingStationPlayerTests {
     return (stationPlayer, playerTracker)
   }
 
+  private func createMockSchedule(stationId: String = "test-station") -> Schedule {
+    let now = Date()
+    let spin = Spin.mockWith(
+      id: "current-spin",
+      airtime: now.addingTimeInterval(-10),
+      stationId: stationId,
+      audioBlock: AudioBlock.mockWith(durationMS: 60000, endOfMessageMS: 60000)
+    )
+    return Schedule(stationId: stationId, spins: [spin])
+  }
+
   // MARK: - Initial State
 
   @Test("Initial state is idle")
@@ -154,6 +165,168 @@ struct StreamingStationPlayerTests {
     let (player, _) = createStationPlayer()
     player.state = .loading
     #expect(!player.isPlaying)
+  }
+  // MARK: - Play Clears Existing Spin Players
+
+  @Test("play() clears existing spin players before starting fresh")
+  func testPlayClearsExistingSpinPlayers() async throws {
+    let tracker = MockAVPlayerTracker()
+    let (player, _) = createStationPlayer(tracker: tracker)
+
+    let mockSchedule = createMockSchedule()
+    player.scheduleFetcher = { _, _ in mockSchedule }
+
+    // Manually add existing spin players to simulate pre-interruption state
+    let staleSpin = Spin.mockWith(id: "stale-spin-1")
+    let staleSpinPlayer = StreamingSpinPlayer(
+      delegate: player,
+      playerFactory: { tracker.createPlayer() }
+    )
+    _ = await staleSpinPlayer.load(staleSpin)
+    player.spinPlayers["stale-spin-1"] = staleSpinPlayer
+
+    let staleSpin2 = Spin.mockWith(id: "stale-spin-2")
+    let staleSpinPlayer2 = StreamingSpinPlayer(
+      delegate: player,
+      playerFactory: { tracker.createPlayer() }
+    )
+    _ = await staleSpinPlayer2.load(staleSpin2)
+    player.spinPlayers["stale-spin-2"] = staleSpinPlayer2
+
+    #expect(player.spinPlayers.count == 2)
+
+    try await player.play(stationId: "test-station")
+
+    // Stale players should be gone, replaced with fresh ones
+    #expect(player.spinPlayers["stale-spin-1"] == nil)
+    #expect(player.spinPlayers["stale-spin-2"] == nil)
+    #expect(!player.spinPlayers.isEmpty)
+  }
+
+  // MARK: - Audio Interruption Handling
+
+  @Test("Interruption began sets correct state when playing")
+  func testInterruptionBeganWhilePlaying() {
+    let (player, _) = createStationPlayer()
+    player.stationId = "test-station"
+    player.state = .playing(Spin.mockWith())
+
+    player.handleInterruptionBegan()
+
+    #expect(player.wasPlayingBeforeInterruption == true)
+    #expect(player.interruptedStationId == "test-station")
+  }
+
+  @Test("Interruption began sets wasPlayingBeforeInterruption false when not playing")
+  func testInterruptionBeganWhileNotPlaying() {
+    let (player, _) = createStationPlayer()
+    player.stationId = "test-station"
+    player.state = .idle
+
+    player.handleInterruptionBegan()
+
+    #expect(player.wasPlayingBeforeInterruption == false)
+    #expect(player.interruptedStationId == "test-station")
+  }
+
+  @Test("Interruption ended with shouldResume triggers resume")
+  func testInterruptionEndedWithShouldResume() async throws {
+    let tracker = MockAVPlayerTracker()
+    let (player, _) = createStationPlayer(tracker: tracker)
+
+    let mockSchedule = createMockSchedule()
+    var fetchCount = 0
+    player.scheduleFetcher = { _, _ in
+      fetchCount += 1
+      return mockSchedule
+    }
+
+    // Simulate interruption began state
+    player.wasPlayingBeforeInterruption = true
+    player.interruptedStationId = "test-station"
+
+    player.handleInterruptionEnded(shouldResume: true)
+
+    // Allow the Task in resumeAfterInterruption to execute
+    try await Task.sleep(for: .milliseconds(100))
+
+    #expect(fetchCount > 0)
+    #expect(player.stationId == "test-station")
+  }
+
+  @Test("Interruption ended without shouldResume does not resume")
+  func testInterruptionEndedWithoutShouldResume() async throws {
+    let (player, _) = createStationPlayer()
+
+    var fetchCount = 0
+    player.scheduleFetcher = { _, _ in
+      fetchCount += 1
+      return createMockSchedule()
+    }
+
+    player.wasPlayingBeforeInterruption = true
+    player.interruptedStationId = "test-station"
+
+    player.handleInterruptionEnded(shouldResume: false)
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    #expect(fetchCount == 0)
+  }
+
+  @Test("resumeAfterInterruption clears interruption flags")
+  func testResumeAfterInterruptionClearsFlags() async throws {
+    let tracker = MockAVPlayerTracker()
+    let (player, _) = createStationPlayer(tracker: tracker)
+
+    let mockSchedule = createMockSchedule()
+    player.scheduleFetcher = { _, _ in mockSchedule }
+
+    player.wasPlayingBeforeInterruption = true
+    player.interruptedStationId = "test-station"
+
+    player.resumeAfterInterruption()
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    #expect(player.interruptedStationId == nil)
+    #expect(player.wasPlayingBeforeInterruption == false)
+  }
+
+  @Test("resumeAfterInterruption with nil stationId does nothing")
+  func testResumeAfterInterruptionNilStationId() async throws {
+    let (player, _) = createStationPlayer()
+
+    var fetchCount = 0
+    player.scheduleFetcher = { _, _ in
+      fetchCount += 1
+      return createMockSchedule()
+    }
+
+    player.interruptedStationId = nil
+
+    player.resumeAfterInterruption()
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    #expect(fetchCount == 0)
+  }
+
+  // MARK: - Headphone Disconnect
+
+  @Test("Headphone disconnect stops playback without setting interruption state")
+  func testHeadphoneDisconnectStopsWithoutInterruptionState() {
+    let (player, _) = createStationPlayer()
+    player.stationId = "test-station"
+    player.state = .playing(Spin.mockWith())
+
+    // Simulate headphone disconnect by calling stop() directly
+    // (this is what handleAudioRouteChange does now — just calls stop())
+    player.stop()
+
+    #expect(player.stationId == nil)
+    #expect(player.interruptedStationId == nil)
+    #expect(player.wasPlayingBeforeInterruption == false)
   }
 }
 


### PR DESCRIPTION
## Summary

Fixed two bugs in StreamingStationPlayer audio interruption handling:

1. **No audio after interruption resume** — `play(stationId:)` now clears existing spin players before starting fresh, preventing stale AVPlayers from being reused after audio interruptions.

2. **Dead headphone disconnect state** — Removed misleading `interruptedStationId` and `wasPlayingBeforeInterruption` state saves from headphone disconnect handler, following Apple's convention of pause-on-disconnect without auto-resume.

Also removed dead `isSuspended` property and added `scheduleFetcher` closure for testability. Includes 8 new tests covering all interruption handling codepaths (17 tests total).

## Test plan
- `swift test` — all 133 tests pass
- `swift test --filter StreamingStationPlayerTests` — 17 tests (9 existing + 8 new)
- Manual verification: resume after phone call produces audio; headphone disconnect cleanly stops playback

🤖 Generated with Claude Code