### PR TITLE
Start audio engine off main thread on interruption resume

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -5,7 +5,7 @@
 //  Created by Brian D Keane on 1/6/25.
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import Foundation
 import PlayolaCore
 import os.log
@@ -138,22 +138,32 @@ open class PlayolaMainMixer: NSObject {
 }
 
 extension PlayolaMainMixer {
-  @MainActor
-  public func start() throws {
+  /// Starts the audio engine off the main thread to avoid blocking on
+  /// AUIOClient_StartIO during cold hardware initialization (e.g. resuming
+  /// from a phone-call interruption). AVAudioEngine.start() is thread-safe.
+  public func start() async throws {
+    let engine = self.engine
     do {
-      try engine.start()
-    } catch {
-      Task {
-        await errorReporter.reportError(
-          error, context: "Failed to start audio engine",
-          level: .critical)
+      try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<Void, Error>) in
+        DispatchQueue.global(qos: .userInitiated).async {
+          do {
+            try engine.start()
+            continuation.resume()
+          } catch {
+            continuation.resume(throwing: error)
+          }
+        }
       }
+    } catch {
+      await errorReporter.reportError(
+        error, context: "Failed to start audio engine",
+        level: .critical)
       throw error
     }
   }
 
-  @MainActor
-  public func restartEngine() throws {
+  public func restartEngine() async throws {
     os_log("Restarting audio engine", log: PlayolaMainMixer.logger, type: .info)
 
     if engine.isRunning {
@@ -161,7 +171,7 @@ extension PlayolaMainMixer {
     }
 
     engine.prepare()
-    try start()
+    try await start()
   }
 
   public var isEngineRunning: Bool {

--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -140,7 +140,9 @@ open class PlayolaMainMixer: NSObject {
 extension PlayolaMainMixer {
   /// Starts the audio engine off the main thread to avoid blocking on
   /// AUIOClient_StartIO during cold hardware initialization (e.g. resuming
-  /// from a phone-call interruption). AVAudioEngine.start() is thread-safe.
+  /// from a phone-call interruption). AVAudioEngine.start() is thread-safe;
+  /// only the start call itself is dispatched off main.
+  @MainActor
   public func start() async throws {
     let engine = self.engine
     do {
@@ -163,6 +165,7 @@ extension PlayolaMainMixer {
     }
   }
 
+  @MainActor
   public func restartEngine() async throws {
     os_log("Restarting audio engine", log: PlayolaMainMixer.logger, type: .info)
 

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -739,7 +739,7 @@ final public class PlayolaStationPlayer: ObservableObject {
       Task { @MainActor in
         do {
           try await PlayolaMainMixer.shared.audioSessionManager.activate()
-          try PlayolaMainMixer.shared.restartEngine()
+          try await PlayolaMainMixer.shared.restartEngine()
           try await self.play(stationId: stationToResume)
         } catch {
           os_log(


### PR DESCRIPTION
## Summary

- `AVAudioEngine.start()` does a synchronous `mach_msg` to the audio server to bring up the hardware. After a phone-call interruption the hardware is cold and this call can exceed the 2s main-thread watchdog, producing Sentry *App Hanging* reports with `AUIOClient_StartIO` at the top of the stack.
- Make `PlayolaMainMixer.start()` async and dispatch the blocking engine start to a background queue via `withCheckedThrowingContinuation`, so the main thread is `await`-suspended rather than blocked. `restartEngine()` follows suit, and `resumeAfterInterruption` now awaits the restart.
- `AVAudioEngine` is documented thread-safe for start/stop; engine topology is only mutated at init/setup on the main actor, so there is no race. `@preconcurrency import AVFoundation` silences the expected `Sendable` warning on the engine capture.

## Scope

Only `PlayolaMainMixer.start` / `restartEngine` and the one caller in `PlayolaStationPlayer.resumeAfterInterruption` are touched. The direct `engine.start()` calls in `SpinPlayer` (`playNow` / `ensureEngineRunning` / `prepareAudioEngine`) are left as-is — those run on the in-flow hot path with an already-active session, which is not where the Sentry hang originates.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — all 87 tests pass
- [ ] Manual: play a station, trigger a phone-call interruption (e.g. incoming FaceTime audio), end the call, verify playback resumes without a hang and no *App Hanging* event appears in Sentry
- [ ] Manual: pull headphones / disconnect Bluetooth during playback and confirm normal cleanup is unaffected