### PR TITLE
Cap all URLSessions to TLS 1.2 to fix iOS 26 middlebox failures

### DIFF
--- a/Sources/PlayolaPlayer/Player/FileDownloaderAsync.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloaderAsync.swift
@@ -34,7 +34,7 @@ public actor FileDownloaderAsync {
   public func download(from url: URL, to destinationURL: URL) async throws -> DownloadResult {
     guard !isCancelled else { throw URLError(.cancelled) }
 
-    let configuration = URLSessionConfiguration.default
+    let configuration = makeTLS12Configuration()
     configuration.timeoutIntervalForRequest = 30
     configuration.timeoutIntervalForResource = 300
     configuration.waitsForConnectivity = true
@@ -84,7 +84,7 @@ public actor FileDownloaderAsync {
         logger: logger
       )
 
-      let configuration = URLSessionConfiguration.default
+      let configuration = makeTLS12Configuration()
       configuration.timeoutIntervalForRequest = 30
       configuration.timeoutIntervalForResource = 300
       configuration.waitsForConnectivity = true

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -66,7 +66,7 @@ public class ListeningSessionReporter {
 
   init(
     stationPlayer: PlayolaStationPlayer, authProvider: PlayolaAuthenticationProvider? = nil,
-    urlSession: URLSessionProtocol = URLSession.shared,
+    urlSession: URLSessionProtocol = tls12Session,
     baseURL: URL = URL(string: "https://admin-api.playola.fm")!
   ) {
     self.stationPlayer = stationPlayer
@@ -307,7 +307,7 @@ public class ListeningSessionReporter {
   #if DEBUG
     internal init(
       authProvider: PlayolaAuthenticationProvider? = nil,
-      urlSession: URLSessionProtocol = URLSession.shared,
+      urlSession: URLSessionProtocol = tls12Session,
       baseURL: URL = URL(string: "https://admin-api.playola.fm")!
     ) {
       self.stationPlayer = nil

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -402,7 +402,7 @@ final public class PlayolaStationPlayer: ObservableObject {
     let url = createScheduleURL(for: stationId)
 
     do {
-      let (data, response) = try await URLSession.shared.data(from: url)
+      let (data, response) = try await tls12Session.data(from: url)
       let httpResponse = try validateHTTPResponse(response, url: url)
       try await validateStatusCode(httpResponse, data: data, stationId: stationId)
 

--- a/Sources/PlayolaPlayer/Player/TLS12Session.swift
+++ b/Sources/PlayolaPlayer/Player/TLS12Session.swift
@@ -18,6 +18,7 @@ import Foundation
 // a supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
 internal func makeTLS12Configuration() -> URLSessionConfiguration {
   let configuration = URLSessionConfiguration.default
+  configuration.tlsMinimumSupportedProtocolVersion = .TLSv12
   configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
   return configuration
 }

--- a/Sources/PlayolaPlayer/Player/TLS12Session.swift
+++ b/Sources/PlayolaPlayer/Player/TLS12Session.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// TEMPORARY: Global TLS 1.2 cap.
+//
+// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
+// post-quantum hybrid key share (~1.6 KB). Some users sit behind middleboxes
+// (antivirus SSL inspection, parental-control routers, captive portals, etc.) that
+// drop the larger ClientHello and surface as NSURLErrorSecureConnectionFailed (-1200).
+// Capping URLSession to TLS 1.2 keeps the ClientHello small enough for these
+// middleboxes to pass through.
+//
+// Every URLSession in this library is routed through `tls12Session` (or a
+// configuration derived from `makeTLS12Configuration()` when a delegate is needed)
+// so audio downloads, schedule fetches, and listening-session reports all succeed
+// on these networks.
+//
+// REVERT WHEN: Apple ships an iOS 26 fix (watch 26.5+ release notes) OR exposes
+// a supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
+internal func makeTLS12Configuration() -> URLSessionConfiguration {
+  let configuration = URLSessionConfiguration.default
+  configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
+  return configuration
+}
+
+internal let tls12Session: URLSession = URLSession(configuration: makeTLS12Configuration())


### PR DESCRIPTION
## Summary

Stopgap for an iOS 26 networking bug. On iOS 26, `URLSession` sends a TLS 1.3 ClientHello that includes the X25519MLKEM768 post-quantum hybrid key share (~1.6 KB). Some users sit behind middleboxes (antivirus SSL inspection, parental-control routers, captive portals) that drop the larger ClientHello and surface it as `NSURLErrorSecureConnectionFailed` (-1200). Capping URLSession to TLS 1.2 keeps the ClientHello small enough to pass through.

The host app already capped its own Alamofire session, but this library creates its own URLSessions with default config. On affected networks, audio downloads from S3 silently fail (no Playola station ever plays), schedule fetches silently fail, and listening sessions aren't reported — end users see a station that "loads" but never plays.

## Changes

Added a new `Sources/PlayolaPlayer/Player/TLS12Session.swift` with:
- `makeTLS12Configuration()` — returns a `URLSessionConfiguration.default` with `tlsMaximumSupportedProtocolVersion = .TLSv12`.
- `tls12Session` — a module-scope shared `URLSession` built from that configuration.

Routed the three call sites through it:
1. **`FileDownloaderAsync.swift`** — both `download(from:to:)` and `performDownload(...)` now build their configuration via `makeTLS12Configuration()` (preserving the existing 30s/300s timeouts and `waitsForConnectivity = true`). This is the load-bearing one — it's what downloads audio from S3.
2. **`PlayolaStationPlayer.swift`** — `getUpdatedSchedule(stationId:)` now uses `tls12Session.data(from:)` instead of `URLSession.shared.data(from:)`.
3. **`ListeningSessionReporter.swift`** — both initializers' `urlSession:` default changed from `URLSession.shared` to `tls12Session`. The parameter is already protocol-typed (`URLSessionProtocol`), so test mocks are unaffected.

A repository-wide grep for `URLSession.shared`, `URLSessionConfiguration.default`, and `URLSession(configuration:` afterwards shows only the intentional usages inside `TLS12Session.swift` and the two `URLSession(configuration: configuration, ...)` lines in `FileDownloaderAsync` where `configuration` now comes from `makeTLS12Configuration()`.

## Why hardcoded, not configurable

This is a temporary workaround for an OS-level bug. Adding a configuration hook would create surface area we'd have to maintain and deprecate when Apple fixes it. Hardcoding keeps the revert trivial — delete one file and undo four call sites.

**REVERT WHEN:** Apple ships an iOS 26 fix (watch 26.5+ release notes) OR exposes a supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.

## Test plan

- [x] `swift build` — succeeds (only pre-existing warnings unrelated to this change)
- [x] `swift test` — all 75 tests in 8 suites pass
- [ ] Smoke test audio playback on a healthy network in the example app
- [ ] If possible, verify station playback works behind a middlebox that was previously failing on iOS 26