### PR TITLE
0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to PlayolaPlayer are documented here. This project follows
 [Semantic Versioning](https://semver.org/). Versions correspond to git tags,
 which Swift Package Manager consumers pin to.
 
+## 0.19.0
+
+### Added
+
+- **Bounded retry/backoff on the initial schedule fetch.** `play(stationId:)`
+  now retries a failed initial `GET /v1/stations/{id}/schedule` up to 3 times
+  with exponential backoff (0.5s / 1s / 2s) before giving up, matching the
+  recovery behavior the player already used for spin loading and the ongoing
+  schedule poll. Only transient failures are retried — server `5xx` responses
+  and connectivity `URLError`s. Permanent failures (`404`, decode errors, empty
+  schedules) still fail fast. This means a transient backend outage no longer
+  instantly fails a station start with no automatic recovery.
+
+### Changed
+
+- **`PlayolaStationPlayer.State` gained a terminal `.error(StationPlayerError)`
+  case.** A failed `play(...)` now emits `.loading(0)` when the attempt begins
+  and `.error(_)` when it fails terminally (instead of throwing without ever
+  changing `state`, which could leave consumers stuck on a loading spinner with
+  no signal). `play(...)` still `throws` as before — the new state is emitted
+  *in addition to* the thrown error. Cancellation does not produce an `.error`
+  state.
+
+  **Source-breaking for consumers** that `switch` exhaustively over `State`:
+  add a `case .error` (or `default`) arm. A typical handler treats `.error` as
+  a recoverable, retry-able state (show the message, let the user tap play
+  again). `StationPlayerError` is now `Sendable`.
+
 ## 0.18.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ which Swift Package Manager consumers pin to.
   previous session immediately, so a *failed* station switch lands on `.error`
   rather than rolling back to the previously-playing station.
 
+- **`playNow(from:to:)` and `schedulePlay(at:)` are now `async`.** Both `public`
+  methods changed from synchronous to `async` so their audio work can run off
+  the main thread. **Source-breaking for direct callers**: add `await` at the
+  call site (callers must already be in an `async` context, e.g. a `Task`).
+
 ## 0.18.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ which Swift Package Manager consumers pin to.
   with exponential backoff (0.5s / 1s / 2s) before giving up, matching the
   recovery behavior the player already used for spin loading and the ongoing
   schedule poll. Only transient failures are retried — server `5xx` responses
-  and connectivity `URLError`s. Permanent failures (`404`, decode errors, empty
-  schedules) still fail fast. This means a transient backend outage no longer
-  instantly fails a station start with no automatic recovery.
+  and an explicit allow-list of connectivity `URLError`s (timeouts, host/DNS,
+  connection-lost, etc.). Permanent failures (`404`, decode errors, empty
+  schedules, and non-connectivity `URLError`s such as `.badURL`) still fail
+  fast. This means a transient backend outage no longer instantly fails a
+  station start with no automatic recovery.
 
 ### Changed
 
@@ -31,6 +33,15 @@ which Swift Package Manager consumers pin to.
   add a `case .error` (or `default`) arm. A typical handler treats `.error` as
   a recoverable, retry-able state (show the message, let the user tap play
   again). `StationPlayerError` is now `Sendable`.
+
+- **State transitions are now supersession-safe (last `play()` wins).** Each
+  `play(...)`/`stop()` takes a new internal generation; work from a prior
+  attempt (its scheduling loop, or a spin whose audio starts later) can no
+  longer publish state into a newer attempt. This closes a race where a
+  lingering session could overwrite a freshly-emitted `.error` (or `.idle`)
+  with `.playing`. Behavioral note: starting a new `play()` supersedes the
+  previous session immediately, so a *failed* station switch lands on `.error`
+  rather than rolling back to the previously-playing station.
 
 ## 0.18.0
 

--- a/PlayolaPlayerExample/PlayolaPlayerExample/ContentView.swift
+++ b/PlayolaPlayerExample/PlayolaPlayerExample/ContentView.swift
@@ -129,6 +129,18 @@ struct ContentView: View {
                   .font(.caption)
                   .foregroundColor(.white.opacity(0.6))
               }
+            } else if case .error(let error) = player.state {
+              VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                  .foregroundColor(.yellow)
+                Text(error.errorDescription ?? "Couldn't start the station")
+                  .font(.subheadline)
+                  .multilineTextAlignment(.center)
+                  .foregroundColor(.white.opacity(0.8))
+                Text("Tap play to try again")
+                  .font(.caption)
+                  .foregroundColor(.white.opacity(0.6))
+              }
             } else {
               Text("Ready to Play")
                 .font(.title3)
@@ -237,12 +249,13 @@ struct ContentView: View {
       case .playing:
         // Stop playing
         await player.stop()
-      case .idle:
-        // Start playing
+      case .idle, .error:
+        // Start (or retry after a failed start)
         do {
           try await player.play(stationId: selectedStationId)
         } catch {
-          // Handle errors gracefully (including cancellation during loading)
+          // Handle errors gracefully (including cancellation during loading).
+          // The terminal .error state is surfaced via player.state above.
           print("Failed to start playback: \(error)")
         }
       }
@@ -493,6 +506,8 @@ func buttonColor(for state: PlayolaStationPlayer.State) -> Color {
     return Color.red
   case .idle:
     return Color.green
+  case .error:
+    return Color.green
   }
 }
 
@@ -504,6 +519,8 @@ func buttonIcon(for state: PlayolaStationPlayer.State) -> String {
     return "stop.fill"
   case .idle:
     return "play.fill"
+  case .error:
+    return "arrow.clockwise"
   }
 }
 

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -12,7 +12,7 @@ import Foundation
 import os.log
 
 /// Errors specific to the station player
-public enum StationPlayerError: Error, LocalizedError {
+public enum StationPlayerError: Error, LocalizedError, Sendable {
   case networkError(String)
   case scheduleError(String)
   case playbackError(String)
@@ -67,6 +67,11 @@ final public class PlayolaStationPlayer: ObservableObject {
   var listeningSessionReporter: ListeningSessionReporter?
   private let errorReporter = PlayolaErrorReporter.shared
   private var authProvider: PlayolaAuthenticationProvider?
+  private let urlSession: URLSessionProtocol
+
+  /// Base delay (seconds) for the initial schedule-fetch exponential backoff.
+  /// Internal so tests can disable the wait; not part of the public API.
+  var scheduleRetryBaseDelay: TimeInterval = 0.5
 
   /// Time offset for playing station from a different point in time
   private var scheduleOffset: TimeInterval?
@@ -118,6 +123,10 @@ final public class PlayolaStationPlayer: ObservableObject {
     case loading(Float)
     case playing(Spin)
     case idle
+    /// Emitted when a playback attempt fails terminally (e.g. the schedule
+    /// fetch exhausted its retries). Lets consumers render a recoverable
+    /// error instead of being stuck in a prior state.
+    case error(StationPlayerError)
   }
 
   @Published public var state: PlayolaStationPlayer.State = .idle {
@@ -136,8 +145,12 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   @MainActor
-  internal init(fileDownloadManager: FileDownloadManaging? = nil) {
+  internal init(
+    fileDownloadManager: FileDownloadManaging? = nil,
+    urlSession: URLSessionProtocol = PlayolaNetworkLoggingSession(wrapping: tls12Session)
+  ) {
     self.fileDownloadManager = fileDownloadManager ?? FileDownloadManagerAsync.shared
+    self.urlSession = urlSession
     self.authProvider = nil
     self.listeningSessionReporter = ListeningSessionReporter(stationPlayer: self, authProvider: nil)
 
@@ -398,20 +411,75 @@ final public class PlayolaStationPlayer: ObservableObject {
       scheduledSpinsCount)
   }
 
+  /// Internal classification so the retry layer can tell transient failures
+  /// (5xx, connectivity) apart from permanent ones (4xx, decode errors)
+  /// without widening the public error surface. `publicError` is what callers
+  /// ultimately receive — the public error API is unchanged.
+  private struct ClassifiedScheduleError: Error {
+    let isTransient: Bool
+    let publicError: Error
+  }
+
+  /// Fetches the schedule with bounded exponential backoff, retrying only
+  /// transient failures (server 5xx and connectivity errors). Permanent
+  /// failures (404, decode errors, empty schedules) fail fast. The error
+  /// thrown to callers is the same public error a single fetch would throw.
+  func getUpdatedScheduleWithRetry(stationId: String) async throws -> Schedule {
+    let maxRetries = 3
+    var attempt = 0
+    while true {
+      do {
+        return try await fetchScheduleOnce(stationId: stationId)
+      } catch let classified as ClassifiedScheduleError {
+        guard classified.isTransient, attempt < maxRetries else {
+          throw classified.publicError
+        }
+        let delay = scheduleRetryBaseDelay * pow(2.0, Double(attempt))
+        if delay > 0 {
+          try await Task.sleep(for: .seconds(delay))
+        }
+        attempt += 1
+      }
+    }
+  }
+
+  /// Single, non-retrying schedule fetch. Used directly by the polling loop;
+  /// re-throws the public error so existing callers see an unchanged surface.
   private func getUpdatedSchedule(stationId: String) async throws -> Schedule {
+    do {
+      return try await fetchScheduleOnce(stationId: stationId)
+    } catch let classified as ClassifiedScheduleError {
+      throw classified.publicError
+    }
+  }
+
+  private func fetchScheduleOnce(stationId: String) async throws -> Schedule {
     let url = createScheduleURL(for: stationId)
 
     do {
-      let loggingSession = PlayolaNetworkLoggingSession(wrapping: tls12Session)
-      let (data, response) = try await loggingSession.data(for: URLRequest(url: url))
+      let (data, response) = try await urlSession.data(for: URLRequest(url: url))
       let httpResponse = try validateHTTPResponse(response, url: url)
       try await validateStatusCode(httpResponse, data: data, stationId: stationId)
 
       return try await decodeSchedule(from: data, stationId: stationId)
+    } catch let classified as ClassifiedScheduleError {
+      await reportScheduleFetchError(classified.publicError, stationId: stationId)
+      throw classified
     } catch {
       await reportScheduleFetchError(error, stationId: stationId)
-      throw error
+      throw classifyScheduleFetchError(error)
     }
+  }
+
+  private func classifyScheduleFetchError(_ error: Error) -> ClassifiedScheduleError {
+    if error is CancellationError {
+      return ClassifiedScheduleError(isTransient: false, publicError: error)
+    }
+    if let urlError = error as? URLError {
+      return ClassifiedScheduleError(
+        isTransient: urlError.code != .cancelled, publicError: error)
+    }
+    return ClassifiedScheduleError(isTransient: false, publicError: error)
   }
 
   private func createScheduleURL(for stationId: String) -> URL {
@@ -446,7 +514,8 @@ final public class PlayolaStationPlayer: ObservableObject {
       await reportHTTPError(
         error, statusCode: httpResponse.statusCode, stationId: stationId, responseText: responseText
       )
-      throw error
+      throw ClassifiedScheduleError(
+        isTransient: (500...599).contains(httpResponse.statusCode), publicError: error)
     }
   }
 
@@ -552,34 +621,58 @@ final public class PlayolaStationPlayer: ObservableObject {
 
     self.stationId = stationId
 
-    // Get the schedule
-    self.currentSchedule = try await getUpdatedSchedule(stationId: stationId)
+    // Emit a terminal-trackable state from the start so consumers observing
+    // $state always see the attempt begin and (below) its success or failure.
+    self.state = .loading(0)
 
-    guard let spinToPlay = currentSchedule?.current(offsetTimeInterval: scheduleOffset).first else {
-      let error = StationPlayerError.scheduleError("No available spins to play")
-      Task {
-        await errorReporter.reportError(
-          error,
-          context:
-            "Schedule for station \(stationId) contains no current spins | "
-            + "Total spins: \(currentSchedule?.spins.count ?? 0)",
-          level: .error)
+    do {
+      // Get the schedule (with bounded backoff for transient outages)
+      self.currentSchedule = try await getUpdatedScheduleWithRetry(stationId: stationId)
+
+      guard
+        let spinToPlay = currentSchedule?.current(offsetTimeInterval: scheduleOffset).first
+      else {
+        let error = StationPlayerError.scheduleError("No available spins to play")
+        Task {
+          await errorReporter.reportError(
+            error,
+            context:
+              "Schedule for station \(stationId) contains no current spins | "
+              + "Total spins: \(currentSchedule?.spins.count ?? 0)",
+            level: .error)
+        }
+        throw error
+      }
+
+      // Log success with context
+      os_log(
+        "Starting playback for station: %@", log: PlayolaStationPlayer.logger, type: .info,
+        stationId)
+
+      // Schedule the first spin with progress shown
+      try await scheduleSpin(spin: spinToPlay, showProgress: true)
+
+      // Schedule upcoming spins
+      schedulingTask?.cancel()
+      schedulingTask = Task {
+        await scheduleUpcomingSpins()
+      }
+    } catch {
+      // Emit a terminal error state so consumers can render a recoverable
+      // error instead of being stuck in .loading. Cancellation is not an error.
+      if !isCancellation(error) {
+        let stationError =
+          (error as? StationPlayerError) ?? .scheduleError(error.localizedDescription)
+        self.state = .error(stationError)
       }
       throw error
     }
+  }
 
-    // Log success with context
-    os_log(
-      "Starting playback for station: %@", log: PlayolaStationPlayer.logger, type: .info, stationId)
-
-    // Schedule the first spin with progress shown
-    try await scheduleSpin(spin: spinToPlay, showProgress: true)
-
-    // Schedule upcoming spins
-    schedulingTask?.cancel()
-    schedulingTask = Task {
-      await scheduleUpcomingSpins()
-    }
+  private func isCancellation(_ error: Error) -> Bool {
+    if error is CancellationError { return true }
+    if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    return false
   }
 
   /// Stops the current playback and releases associated resources.

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -86,6 +86,13 @@ final public class PlayolaStationPlayer: ObservableObject {
   // scheduling loop, or a spin whose audio starts after a newer attempt began —
   // must not publish state into the current generation. Internal for tests.
   var playGeneration: Int = 0
+
+  /// Whether work tagged with `generation` belongs to the current play attempt.
+  /// The gate that stops a superseded session from publishing state. Internal
+  /// so tests can assert it without constructing a CoreAudio-backed SpinPlayer.
+  func isCurrentGeneration(_ generation: Int) -> Bool {
+    generation == playGeneration
+  }
   private var playTask: Task<Void, Error>?
 
   // Audio interruption state
@@ -920,7 +927,7 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
   public func player(_ player: SpinPlayer, startedPlaying spin: Spin) {
     // Ignore callbacks from a superseded session — otherwise a spin scheduled by
     // a prior play() could flip a newer .loading/.error/.idle state to .playing.
-    guard player.playGeneration == playGeneration else {
+    guard isCurrentGeneration(player.playGeneration) else {
       os_log(
         "Ignoring startedPlaying from superseded generation: %@",
         log: PlayolaStationPlayer.logger, type: .info, spin.id)

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -80,6 +80,12 @@ final public class PlayolaStationPlayer: ObservableObject {
 
   // Internal (not private) so tests can observe scheduling-task lifecycle.
   var schedulingTask: Task<Void, Never>?
+
+  // Monotonic token identifying the current play() attempt. Bumped on every
+  // play() and stop(). Work started by an older generation — a prior session's
+  // scheduling loop, or a spin whose audio starts after a newer attempt began —
+  // must not publish state into the current generation. Internal for tests.
+  var playGeneration: Int = 0
   private var playTask: Task<Void, Error>?
 
   // Audio interruption state
@@ -202,12 +208,14 @@ final public class PlayolaStationPlayer: ObservableObject {
 
     try validateSpinForScheduling(spin)
     let spinPlayer = getAvailableSpinPlayer()
+    spinPlayer.playGeneration = playGeneration
     cancelExistingDownload(for: spin.id)
 
     do {
       let result = await loadSpinWithProgress(spin, spinPlayer, showProgress)
       try await handleLoadResult(
-        result, spin: spin, showProgress: showProgress, retryCount: retryCount)
+        result, spin: spin, spinPlayer: spinPlayer, showProgress: showProgress,
+        retryCount: retryCount)
     } catch {
       try await handleSchedulingError(
         error, spin: spin, showProgress: showProgress, retryCount: retryCount)
@@ -251,19 +259,21 @@ final public class PlayolaStationPlayer: ObservableObject {
     return await spinPlayer.load(
       spin,
       onDownloadProgress: { [weak self] progress in
-        guard let self = self, showProgress else { return }
+        guard let self = self, showProgress,
+          spinPlayer.playGeneration == self.playGeneration
+        else { return }
         self.state = .loading(progress)
       }
     )
   }
 
   private func handleLoadResult(
-    _ result: Result<URL, Error>, spin: Spin, showProgress: Bool,
+    _ result: Result<URL, Error>, spin: Spin, spinPlayer: SpinPlayer, showProgress: Bool,
     retryCount: Int
   ) async throws {
     switch result {
     case .success:
-      if showProgress {
+      if showProgress, spinPlayer.playGeneration == playGeneration {
         self.state = .playing(spin)
       }
     case .failure(let error):
@@ -346,14 +356,16 @@ final public class PlayolaStationPlayer: ObservableObject {
   private let schedulePollingInterval: UInt64 = 20_000_000_000  // 20 seconds in nanoseconds
 
   @MainActor
-  private func scheduleUpcomingSpins() async {
+  private func scheduleUpcomingSpins(generation: Int) async {
     guard let stationId else {
       let error = StationPlayerError.invalidStationId("No station ID available")
       Task { await errorReporter.reportError(error, level: .warning) }
       return
     }
 
-    while !Task.isCancelled {
+    // Stop as soon as a newer play()/stop() supersedes this loop, even if this
+    // task hasn't hit a cooperative cancellation point yet.
+    while !Task.isCancelled && generation == playGeneration {
       do {
         try await performScheduleUpdate(stationId: stationId)
       } catch is CancellationError {
@@ -480,13 +492,22 @@ final public class PlayolaStationPlayer: ObservableObject {
     }
   }
 
+  /// Connectivity-related `URLError`s that a retry can plausibly recover from.
+  /// Non-connectivity failures (e.g. `.badURL`, `.unsupportedURL`) are permanent
+  /// and must fail fast instead of burning the backoff budget.
+  private static let retryableURLErrorCodes: Set<URLError.Code> = [
+    .timedOut, .cannotConnectToHost, .cannotFindHost, .networkConnectionLost,
+    .notConnectedToInternet, .dnsLookupFailed, .resourceUnavailable,
+    .secureConnectionFailed,
+  ]
+
   private func classifyScheduleFetchError(_ error: Error) -> ClassifiedScheduleError {
     if error is CancellationError {
       return ClassifiedScheduleError(isTransient: false, publicError: error)
     }
     if let urlError = error as? URLError {
-      return ClassifiedScheduleError(
-        isTransient: urlError.code != .cancelled, publicError: error)
+      let isTransient = Self.retryableURLErrorCodes.contains(urlError.code)
+      return ClassifiedScheduleError(isTransient: isTransient, publicError: error)
     }
     return ClassifiedScheduleError(isTransient: false, publicError: error)
   }
@@ -630,6 +651,12 @@ final public class PlayolaStationPlayer: ObservableObject {
 
     self.stationId = stationId
 
+    // Take over as the current play attempt. Any in-flight work from a prior
+    // attempt (its scheduling loop, late spin callbacks) belongs to an older
+    // generation and will no longer publish into state.
+    playGeneration += 1
+    let generation = playGeneration
+
     // Emit a terminal-trackable state from the start so consumers observing
     // $state always see the attempt begin and (below) its success or failure.
     self.state = .loading(0)
@@ -637,6 +664,10 @@ final public class PlayolaStationPlayer: ObservableObject {
     do {
       // Get the schedule (with bounded backoff for transient outages)
       self.currentSchedule = try await getUpdatedScheduleWithRetry(stationId: stationId)
+
+      // A newer play()/stop() superseded us mid-fetch — abandon quietly so we
+      // don't write into a session we no longer own.
+      guard generation == playGeneration else { return }
 
       guard
         let spinToPlay = currentSchedule?.current(offsetTimeInterval: scheduleOffset).first
@@ -661,17 +692,20 @@ final public class PlayolaStationPlayer: ObservableObject {
       // Schedule the first spin with progress shown
       try await scheduleSpin(spin: spinToPlay, showProgress: true)
 
-      // Schedule upcoming spins
+      // Superseded while loading the first spin — don't start a scheduling loop.
+      guard generation == playGeneration else { return }
+
+      // Take over the scheduling loop from any prior session and start our own.
       schedulingTask?.cancel()
-      schedulingTask = Task {
-        await scheduleUpcomingSpins()
+      schedulingTask = Task { [generation] in
+        await scheduleUpcomingSpins(generation: generation)
       }
     } catch {
-      // Cancel any scheduling loop left running by a prior successful play().
-      // Otherwise it keeps polling and a completing spin would flip the state
-      // we set below back to .playing, masking the failure.
-      schedulingTask?.cancel()
-      schedulingTask = nil
+      // Only publish the failure if we're still the current attempt. A newer
+      // play()/stop() owns state now, and a prior session's still-running loop
+      // is gated by generation rather than force-cancelled here (it would
+      // otherwise tear down a live session this failed attempt never started).
+      guard generation == playGeneration else { throw error }
 
       // Emit a terminal error state so consumers can render a recoverable
       // error instead of being stuck in .loading. Cancellation is not an error.
@@ -707,6 +741,10 @@ final public class PlayolaStationPlayer: ObservableObject {
   /// 4. Reports the end of the listening session
   public func stop() {
     os_log("🛑 STOP called", log: PlayolaStationPlayer.logger, type: .info)
+
+    // Supersede any in-flight play()/scheduling work so it can't publish state
+    // after we go idle.
+    playGeneration += 1
 
     // Log current state before stopping
     os_log(
@@ -880,14 +918,23 @@ final public class PlayolaStationPlayer: ObservableObject {
 
 extension PlayolaStationPlayer: SpinPlayerDelegate {
   public func player(_ player: SpinPlayer, startedPlaying spin: Spin) {
+    // Ignore callbacks from a superseded session — otherwise a spin scheduled by
+    // a prior play() could flip a newer .loading/.error/.idle state to .playing.
+    guard player.playGeneration == playGeneration else {
+      os_log(
+        "Ignoring startedPlaying from superseded generation: %@",
+        log: PlayolaStationPlayer.logger, type: .info, spin.id)
+      return
+    }
+
     os_log("Started playing: %@", log: PlayolaStationPlayer.logger, type: .info, spin.id)
 
     self.state = .playing(spin)
 
     schedulingTask?.cancel()
-    schedulingTask = Task {
+    schedulingTask = Task { [generation = playGeneration] in
       do {
-        await self.scheduleUpcomingSpins()
+        await self.scheduleUpcomingSpins(generation: generation)
 
         // Get a list of active file paths to exclude from pruning
         let activePaths = self._spinPlayers

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -214,14 +214,19 @@ final public class PlayolaStationPlayer: ObservableObject {
       retryCount)
 
     try validateSpinForScheduling(spin)
+    // Capture the generation immutably for this scheduling work. Async
+    // callbacks below compare against this local rather than reading it back
+    // off the reusable SpinPlayer, whose tag could be overwritten if the player
+    // is recycled by a newer attempt.
+    let generation = playGeneration
     let spinPlayer = getAvailableSpinPlayer()
-    spinPlayer.playGeneration = playGeneration
+    spinPlayer.playGeneration = generation
     cancelExistingDownload(for: spin.id)
 
     do {
-      let result = await loadSpinWithProgress(spin, spinPlayer, showProgress)
+      let result = await loadSpinWithProgress(spin, spinPlayer, generation, showProgress)
       try await handleLoadResult(
-        result, spin: spin, spinPlayer: spinPlayer, showProgress: showProgress,
+        result, spin: spin, generation: generation, showProgress: showProgress,
         retryCount: retryCount)
     } catch {
       try await handleSchedulingError(
@@ -261,26 +266,24 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   private func loadSpinWithProgress(
-    _ spin: Spin, _ spinPlayer: SpinPlayer, _ showProgress: Bool
+    _ spin: Spin, _ spinPlayer: SpinPlayer, _ generation: Int, _ showProgress: Bool
   ) async -> Result<URL, Error> {
     return await spinPlayer.load(
       spin,
       onDownloadProgress: { [weak self] progress in
-        guard let self = self, showProgress,
-          spinPlayer.playGeneration == self.playGeneration
-        else { return }
+        guard let self = self, showProgress, self.isCurrentGeneration(generation) else { return }
         self.state = .loading(progress)
       }
     )
   }
 
   private func handleLoadResult(
-    _ result: Result<URL, Error>, spin: Spin, spinPlayer: SpinPlayer, showProgress: Bool,
+    _ result: Result<URL, Error>, spin: Spin, generation: Int, showProgress: Bool,
     retryCount: Int
   ) async throws {
     switch result {
     case .success:
-      if showProgress, spinPlayer.playGeneration == playGeneration {
+      if showProgress, isCurrentGeneration(generation) {
         self.state = .playing(spin)
       }
     case .failure(let error):

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -684,9 +684,17 @@ final public class PlayolaStationPlayer: ObservableObject {
     }
   }
 
-  private func isCancellation(_ error: Error) -> Bool {
+  // Internal for testability. Kept consistent with `shouldSkipRetry`: a
+  // cancelled in-flight download (thrown by scheduleSpin when stop() runs) is a
+  // cancellation, not a terminal error, and must not flip state to .error.
+  func isCancellation(_ error: Error) -> Bool {
     if error is CancellationError { return true }
     if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    if let fileDownloadError = error as? FileDownloadError,
+      case .downloadCancelled = fileDownloadError
+    {
+      return true
+    }
     return false
   }
 

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -424,6 +424,9 @@ final public class PlayolaStationPlayer: ObservableObject {
   /// transient failures (server 5xx and connectivity errors). Permanent
   /// failures (404, decode errors, empty schedules) fail fast. The error
   /// thrown to callers is the same public error a single fetch would throw.
+  ///
+  /// Intentionally `internal` (not `private`) for test access, matching
+  /// `scheduleRetryBaseDelay`; not part of the public API.
   func getUpdatedScheduleWithRetry(stationId: String) async throws -> Schedule {
     let maxRetries = 3
     var attempt = 0
@@ -463,9 +466,14 @@ final public class PlayolaStationPlayer: ObservableObject {
 
       return try await decodeSchedule(from: data, stationId: stationId)
     } catch let classified as ClassifiedScheduleError {
-      await reportScheduleFetchError(classified.publicError, stationId: stationId)
+      // HTTP-status failures are already reported once by validateStatusCode.
       throw classified
+    } catch let stationError as StationPlayerError {
+      // validateHTTPResponse and decodeSchedule already reported these once.
+      throw classifyScheduleFetchError(stationError)
     } catch {
+      // Raw transport error (e.g. URLError) — not reported by any inner step,
+      // so report it here exactly once.
       await reportScheduleFetchError(error, stationId: stationId)
       throw classifyScheduleFetchError(error)
     }

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -78,7 +78,8 @@ final public class PlayolaStationPlayer: ObservableObject {
 
   private var activeDownloadIds: [String: UUID] = [:]
 
-  private var schedulingTask: Task<Void, Never>?
+  // Internal (not private) so tests can observe scheduling-task lifecycle.
+  var schedulingTask: Task<Void, Never>?
   private var playTask: Task<Void, Error>?
 
   // Audio interruption state
@@ -666,6 +667,12 @@ final public class PlayolaStationPlayer: ObservableObject {
         await scheduleUpcomingSpins()
       }
     } catch {
+      // Cancel any scheduling loop left running by a prior successful play().
+      // Otherwise it keeps polling and a completing spin would flip the state
+      // we set below back to .playing, masking the failure.
+      schedulingTask?.cancel()
+      schedulingTask = nil
+
       // Emit a terminal error state so consumers can render a recoverable
       // error instead of being stuck in .loading. Cancellation is not an error.
       if !isCancellation(error) {

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -206,7 +206,9 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   @MainActor
-  private func scheduleSpin(spin: Spin, showProgress: Bool = false, retryCount: Int = 0)
+  private func scheduleSpin(
+    spin: Spin, generation: Int, showProgress: Bool = false, retryCount: Int = 0
+  )
     async throws
   {
     os_log(
@@ -214,11 +216,9 @@ final public class PlayolaStationPlayer: ObservableObject {
       retryCount)
 
     try validateSpinForScheduling(spin)
-    // Capture the generation immutably for this scheduling work. Async
-    // callbacks below compare against this local rather than reading it back
-    // off the reusable SpinPlayer, whose tag could be overwritten if the player
-    // is recycled by a newer attempt.
-    let generation = playGeneration
+    // The generation is threaded in from the caller (play() or the scheduling
+    // loop), not re-read from the mutable global, so a caller that has already
+    // been superseded can't tag a player as the current attempt.
     let spinPlayer = getAvailableSpinPlayer()
     spinPlayer.playGeneration = generation
     cancelExistingDownload(for: spin.id)
@@ -230,7 +230,8 @@ final public class PlayolaStationPlayer: ObservableObject {
         retryCount: retryCount)
     } catch {
       try await handleSchedulingError(
-        error, spin: spin, showProgress: showProgress, retryCount: retryCount)
+        error, spin: spin, generation: generation, showProgress: showProgress,
+        retryCount: retryCount)
     }
   }
 
@@ -288,11 +289,14 @@ final public class PlayolaStationPlayer: ObservableObject {
       }
     case .failure(let error):
       try await handleLoadFailure(
-        error, spin: spin, showProgress: showProgress, retryCount: retryCount)
+        error, spin: spin, generation: generation, showProgress: showProgress,
+        retryCount: retryCount)
     }
   }
 
-  private func handleLoadFailure(_ error: Error, spin: Spin, showProgress: Bool, retryCount: Int)
+  private func handleLoadFailure(
+    _ error: Error, spin: Spin, generation: Int, showProgress: Bool, retryCount: Int
+  )
     async throws
   {
     if shouldSkipRetry(for: error) {
@@ -305,18 +309,20 @@ final public class PlayolaStationPlayer: ObservableObject {
     }
 
     try await retryIfPossible(
-      spin: spin, showProgress: showProgress, retryCount: retryCount, fallbackError: error)
+      spin: spin, generation: generation, showProgress: showProgress, retryCount: retryCount,
+      fallbackError: error)
   }
 
   private func handleSchedulingError(
-    _ error: Error, spin: Spin, showProgress: Bool, retryCount: Int
+    _ error: Error, spin: Spin, generation: Int, showProgress: Bool, retryCount: Int
   ) async throws {
     if shouldSkipRetry(for: error) {
       throw error
     }
 
     try await retryIfPossible(
-      spin: spin, showProgress: showProgress, retryCount: retryCount, fallbackError: error)
+      spin: spin, generation: generation, showProgress: showProgress, retryCount: retryCount,
+      fallbackError: error)
   }
 
   private func shouldSkipRetry(for error: Error) -> Bool {
@@ -338,14 +344,17 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   private func retryIfPossible(
-    spin: Spin, showProgress: Bool, retryCount: Int, fallbackError: Error
+    spin: Spin, generation: Int, showProgress: Bool, retryCount: Int, fallbackError: Error
   ) async throws {
     let maxRetries = 3
     if retryCount < maxRetries {
       let delay = TimeInterval(0.5 * pow(2.0, Double(retryCount)))
       try await Task.sleep(for: .seconds(delay))
+      // A newer play()/stop() superseded us during backoff — abandon the retry
+      // rather than reviving a stale session's spin.
+      guard isCurrentGeneration(generation) else { return }
       try await self.scheduleSpin(
-        spin: spin, showProgress: showProgress, retryCount: retryCount + 1)
+        spin: spin, generation: generation, showProgress: showProgress, retryCount: retryCount + 1)
     } else {
       let finalError =
         fallbackError is StationPlayerError
@@ -377,7 +386,7 @@ final public class PlayolaStationPlayer: ObservableObject {
     // task hasn't hit a cooperative cancellation point yet.
     while !Task.isCancelled && generation == playGeneration {
       do {
-        try await performScheduleUpdate(stationId: stationId)
+        try await performScheduleUpdate(stationId: stationId, generation: generation)
       } catch is CancellationError {
         os_log("📛 Schedule update cancelled", log: PlayolaStationPlayer.logger, type: .info)
         return
@@ -400,8 +409,12 @@ final public class PlayolaStationPlayer: ObservableObject {
   }
 
   @MainActor
-  private func performScheduleUpdate(stationId: String) async throws {
+  private func performScheduleUpdate(stationId: String, generation: Int) async throws {
     let updatedSchedule = try await getUpdatedSchedule(stationId: stationId)
+
+    // A newer play()/stop() superseded this loop while the fetch was in flight —
+    // don't schedule the old session's spins into the new attempt.
+    guard isCurrentGeneration(generation) else { return }
 
     os_log(
       "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
@@ -420,11 +433,14 @@ final public class PlayolaStationPlayer: ObservableObject {
 
     for spin in spinsToLoad {
       try Task.checkCancellation()
+      // Re-check between spins: scheduleSpin awaits a download, during which a
+      // newer attempt can supersede us.
+      guard isCurrentGeneration(generation) else { return }
       if !isScheduled(spin: spin) {
         os_log(
           "Scheduling new spin: %@ at %@", log: PlayolaStationPlayer.logger, type: .info,
           spin.id, ISO8601DateFormatter().string(from: spin.airtime))
-        try await scheduleSpin(spin: spin)
+        try await scheduleSpin(spin: spin, generation: generation)
       }
     }
 
@@ -673,11 +689,12 @@ final public class PlayolaStationPlayer: ObservableObject {
 
     do {
       // Get the schedule (with bounded backoff for transient outages)
-      self.currentSchedule = try await getUpdatedScheduleWithRetry(stationId: stationId)
+      let schedule = try await getUpdatedScheduleWithRetry(stationId: stationId)
 
-      // A newer play()/stop() superseded us mid-fetch — abandon quietly so we
-      // don't write into a session we no longer own.
+      // A newer play()/stop() superseded us mid-fetch — abandon quietly without
+      // writing the stale schedule into the shared field we no longer own.
       guard generation == playGeneration else { return }
+      self.currentSchedule = schedule
 
       guard
         let spinToPlay = currentSchedule?.current(offsetTimeInterval: scheduleOffset).first
@@ -700,7 +717,7 @@ final public class PlayolaStationPlayer: ObservableObject {
         stationId)
 
       // Schedule the first spin with progress shown
-      try await scheduleSpin(spin: spinToPlay, showProgress: true)
+      try await scheduleSpin(spin: spinToPlay, generation: generation, showProgress: true)
 
       // Superseded while loading the first spin — don't start a scheduling loop.
       guard generation == playGeneration else { return }

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -93,7 +93,6 @@ final public class PlayolaStationPlayer: ObservableObject {
   func isCurrentGeneration(_ generation: Int) -> Bool {
     generation == playGeneration
   }
-  private var playTask: Task<Void, Error>?
 
   // Audio interruption state
   private var isSuspended = false
@@ -511,9 +510,14 @@ final public class PlayolaStationPlayer: ObservableObject {
       // validateHTTPResponse and decodeSchedule already reported these once.
       throw classifyScheduleFetchError(stationError)
     } catch {
-      // Raw transport error (e.g. URLError) — not reported by any inner step,
-      // so report it here exactly once.
-      await reportScheduleFetchError(error, stationId: stationId)
+      // A cancellation (a routine stop() during an in-flight fetch) is not a
+      // reportable failure — skip the production error event but still
+      // propagate so the caller treats it as a cancellation, not an error.
+      if !isCancellation(error) {
+        // Raw transport error (e.g. URLError) — not reported by any inner step,
+        // so report it here exactly once.
+        await reportScheduleFetchError(error, stationId: stationId)
+      }
       throw classifyScheduleFetchError(error)
     }
   }
@@ -669,9 +673,6 @@ final public class PlayolaStationPlayer: ObservableObject {
     wasPlayingBeforeInterruption = false
     interruptedStationId = nil
 
-    // Cancel any existing play task
-    playTask?.cancel()
-
     // Calculate schedule offset if atDate is provided
     self.scheduleOffset = atDate?.timeIntervalSinceNow
 
@@ -783,12 +784,6 @@ final public class PlayolaStationPlayer: ObservableObject {
       os_log("Cancelling scheduling task", log: PlayolaStationPlayer.logger, type: .info)
       schedulingTask?.cancel()
       schedulingTask = nil
-    }
-
-    if playTask != nil {
-      os_log("Cancelling play task", log: PlayolaStationPlayer.logger, type: .info)
-      playTask?.cancel()
-      playTask = nil
     }
 
     // Stop all players (this will cancel their individual downloads)

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -5,10 +5,16 @@
 //  Created by Brian D Keane on 1/6/25.
 //
 // swiftlint:disable file_length
-import AVFoundation
+// `@preconcurrency` lets us hand AVAudioPlayerNode / AVAudioFile (not Sendable)
+// to the serial `audioControlQueue` closures. Threading contract: only the
+// node/engine *control* calls run off-main, always on that one serial queue,
+// and the closures capture node locals — never main-actor `self` state. Mirrors
+// PlayolaMainMixer.start().
+@preconcurrency import AVFoundation
 import AudioToolbox
 import Foundation
 import PlayolaCore
+import os
 import os.log
 
 #if os(iOS)
@@ -78,6 +84,61 @@ public class SpinPlayer {
 
   // MARK: - Download State
   private var activeDownloadId: UUID?
+
+  // MARK: - Audio Control Threading
+  /// Serial queue for blocking AVAudioEngine / AVAudioPlayerNode control-plane
+  /// calls (start/stop/scheduleSegment/play). Running them off the main thread
+  /// avoids the App Hangs caused by `awaitIOCycle` blocking the main thread;
+  /// keeping them on a single serial queue preserves play-vs-stop ordering now
+  /// that they no longer share the main actor's implicit serialization.
+  private let audioControlQueue = DispatchQueue(
+    label: "fm.playola.spinplayer.audio-control", qos: .userInitiated)
+
+  /// Monotonic token bumped whenever playback is superseded (a new play starts
+  /// or the player is cleared/stopped). Captured before an off-main `await` and
+  /// re-checked after, so a continuation resumed from a superseded session never
+  /// mutates state or notifies the delegate.
+  private var playbackEpoch: Int = 0
+
+  /// Thread-safe mirror of `playbackEpoch` so a queued audio-control block can
+  /// check, off-main, whether it was superseded before it actually starts the
+  /// node — preventing a play() that was queued behind a long IO wait from
+  /// restarting audio after a clear()/stop().
+  private let atomicEpoch = OSAllocatedUnfairLock(initialState: 0)
+
+  /// Bumps the playback epoch (main-actor truth + thread-safe mirror).
+  @discardableResult
+  private func bumpEpoch() -> Int {
+    playbackEpoch += 1
+    let newEpoch = playbackEpoch
+    atomicEpoch.withLock { $0 = newEpoch }
+    return newEpoch
+  }
+
+  /// Marks the start of a new playback attempt, superseding any prior in-flight
+  /// (possibly suspended) playback on this player. Returns the epoch to re-check
+  /// after each subsequent `await`.
+  private func beginPlayback() -> Int {
+    bumpEpoch()
+  }
+
+  /// Runs a blocking AVAudioPlayerNode/AVAudioEngine control operation on the
+  /// serial audio-control queue, off the main thread, and suspends until it
+  /// completes. The op is skipped if `epoch` is no longer current by the time
+  /// the block runs (a clear()/stop()/newer play superseded it). Capture node
+  /// references into locals before calling — do not touch main-actor `self`
+  /// state inside `operation`.
+  private func runAudioControl(
+    epoch: Int, _ operation: @escaping @Sendable () -> Void
+  ) async {
+    let epochLock = atomicEpoch
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      audioControlQueue.async {
+        if epochLock.withLock({ $0 }) == epoch { operation() }
+        continuation.resume()
+      }
+    }
+  }
 
   // MARK: - Playback State
   private var currentVolume: Float = 1.0
@@ -273,8 +334,24 @@ public class SpinPlayer {
   private func stopAudio() {
     // Only stop if the engine is running - no need to start it just to stop
     guard engine.isRunning else { return }
-    playerNode.stop()
-    playerNode.reset()
+    // Enqueue on the serial audio-control queue so this stop is mutually
+    // exclusive with — and ordered after — any in-flight off-main play()/
+    // scheduleSegment for the same node. That ordering is what prevents a play
+    // that was queued behind a long IO wait from leaving orphaned audio after
+    // clear()/stop(). Fire-and-forget: teardown needn't be awaited, and the
+    // epoch bump in clear() already blocks stale main-actor state writes.
+    //
+    // Residual (accepted Option-A scope): hardResetTrackMixer() still runs on
+    // the main actor in clear(), so its graph surgery is not serialized against
+    // these queue blocks. playerNode itself is never detached there (only the
+    // trackMixer is recreated), and AVAudioEngine supports node ops / graph
+    // reconfiguration while running, so this is safe; full serialization of the
+    // graph teardown would be the Option-B follow-up.
+    let node = playerNode
+    audioControlQueue.async {
+      node.stop()
+      node.reset()
+    }
   }
 
   private func clear() {
@@ -284,6 +361,11 @@ public class SpinPlayer {
       type: .debug,
       self.id.uuidString
     )
+
+    // Supersede any in-flight (possibly suspended) playback so a resumed
+    // continuation can't write state or notify, and any queued audio-control
+    // block skips its play(), after we've cleared.
+    bumpEpoch()
 
     stopAudio()
 
@@ -343,40 +425,34 @@ public class SpinPlayer {
   ///   - to: Optional end position in seconds (not implemented in current version)
   ///
   /// If this method is called on a spin that is not loaded, playback will not start.
-  public func playNow(from: Double, to: Double? = nil) {
+  public func playNow(from: Double, to: Double? = nil) async {
+    let epoch = beginPlayback()
+    os_log(
+      "Starting playback from position %f",
+      log: SpinPlayer.logger,
+      type: .info,
+      from
+    )
+    // Record that we're starting mid-file so fades can be shifted appropriately
+    self.playbackStartOffset = from
+    // Callers must await ensureAudioSessionConfigured() before calling playNow.
+    // The fire-and-forget fallback avoids a crash but may still race.
+    assert(
+      playolaMainMixer.audioSessionManager.isConfigured,
+      "Audio session must be configured before calling playNow — call ensureAudioSessionConfigured() first"
+    )
+    playolaMainMixer.configureAudioSession()
+
     do {
-      os_log(
-        "Starting playback from position %f",
-        log: SpinPlayer.logger,
-        type: .info,
-        from
-      )
-      // Record that we're starting mid-file so fades can be shifted appropriately
-      self.playbackStartOffset = from
-      // Callers must await ensureAudioSessionConfigured() before calling playNow.
-      // The fire-and-forget fallback avoids a crash but may still race.
-      assert(
-        playolaMainMixer.audioSessionManager.isConfigured,
-        "Audio session must be configured before calling playNow — call ensureAudioSessionConfigured() first"
-      )
-      playolaMainMixer.configureAudioSession()
+      // Start the engine off the main thread (AUIOClient_StartIO blocks the
+      // caller on cold hardware init). No-op if already running.
       if !engine.isRunning {
-        try engine.start()
+        try await playolaMainMixer.start()
       }
-
-      guard let audioFile = validateAndGetCurrentFile() else { return }
-      scheduleAndPlaySegment(audioFile: audioFile, from: from)
-
-      self.state = .playing
-      if let spin {
-        delegate?.player(self, startedPlaying: spin)
-      }
-      os_log(
-        "Successfully started playback",
-        log: SpinPlayer.logger,
-        type: .info
-      )
     } catch {
+      // If superseded, a stop()/clear() likely caused this failure (e.g. session
+      // torn down) — don't report stale noise or overwrite the new state.
+      guard epoch == playbackEpoch else { return }
       Task {
         await errorReporter.reportError(
           error,
@@ -385,7 +461,26 @@ public class SpinPlayer {
         )
       }
       self.state = .available
+      return
     }
+
+    // A stop()/clear() (or newer play) may have superseded us while the engine
+    // started off-main.
+    guard epoch == playbackEpoch else { return }
+    guard let audioFile = validateAndGetCurrentFile() else { return }
+
+    await scheduleAndPlaySegment(audioFile: audioFile, from: from, epoch: epoch)
+
+    guard epoch == playbackEpoch else { return }
+    self.state = .playing
+    if let spin {
+      delegate?.player(self, startedPlaying: spin)
+    }
+    os_log(
+      "Successfully started playback",
+      log: SpinPlayer.logger,
+      type: .info
+    )
   }
 
   private func validateAndGetCurrentFile() -> AVAudioFile? {
@@ -401,23 +496,30 @@ public class SpinPlayer {
     return currentFile
   }
 
-  private func scheduleAndPlaySegment(audioFile: AVAudioFile, from: Double) {
-    // calculate segment info
-    let sampleRate = playerNode.outputFormat(forBus: 0).sampleRate
-    let newSampleTime = AVAudioFramePosition(sampleRate * from)
-    let framesToPlay = AVAudioFrameCount(Float(sampleRate) * Float(duration))
+  private func scheduleAndPlaySegment(audioFile: AVAudioFile, from: Double, epoch: Int) async {
+    // Capture main-actor state into locals so the off-main block never touches
+    // `self`. `playerNode.outputFormat`/`stop`/`play` can each block on the
+    // audio IO cycle, so the whole sequence runs on the serial control queue.
+    let node = playerNode
+    let fileDuration = duration
 
-    // stop the player, schedule the segment, restart the player
-    // Volume is already set before playNow is called
-    playerNode.stop()
-    playerNode.scheduleSegment(
-      audioFile,
-      startingFrame: newSampleTime,
-      frameCount: framesToPlay,
-      at: nil,
-      completionHandler: nil
-    )
-    playerNode.play()
+    await runAudioControl(epoch: epoch) {
+      let sampleRate = node.outputFormat(forBus: 0).sampleRate
+      let newSampleTime = AVAudioFramePosition(sampleRate * from)
+      let framesToPlay = AVAudioFrameCount(Float(sampleRate) * Float(fileDuration))
+
+      // stop the player, schedule the segment, restart the player
+      // Volume is already set before playNow is called
+      node.stop()
+      node.scheduleSegment(
+        audioFile,
+        startingFrame: newSampleTime,
+        frameCount: framesToPlay,
+        at: nil,
+        completionHandler: nil
+      )
+      node.play()
+    }
   }
 
   // MARK: - Loading and Download Management
@@ -526,12 +628,20 @@ public class SpinPlayer {
         return
       }
 
+      // A stop()/clear() or a newer load() may have superseded this download
+      // while we were suspended on the awaits above. If the player no longer
+      // owns this spin, abandon playback so we don't drive stale audio.
+      guard self.spin?.id == spin.id else {
+        continuation.resume(returning: .success(localUrl))
+        return
+      }
+
       // Determine what to do based on the spin's timing state
       switch spin.playbackTiming {
       case .future:
         // Spin is in the future - schedule it
         self.volume = spin.startingVolume
-        self.schedulePlay(at: spin.airtime)
+        await self.schedulePlay(at: spin.airtime)
 
       case .playing:
         // Spin should be currently playing - start from current position
@@ -539,7 +649,7 @@ public class SpinPlayer {
         self.volume = spin.volumeAtDate(currentDate)
 
         let currentTimeInSeconds = currentDate.timeIntervalSince(spin.airtime)
-        self.playNow(from: currentTimeInSeconds)
+        await self.playNow(from: currentTimeInSeconds)
 
       case .tooLateToStart, .past:
         // Spin has already finished or has too little time left - skip it entirely
@@ -552,6 +662,13 @@ public class SpinPlayer {
         )
         // Clean up everything since we're not going to play this spin
         self.clear()
+        continuation.resume(returning: .success(localUrl))
+        return
+      }
+
+      // schedulePlay/playNow may have suspended on their own off-main awaits;
+      // re-check ownership before the final (unguarded) state writes.
+      guard self.spin?.id == spin.id else {
         continuation.resume(returning: .success(localUrl))
         return
       }
@@ -798,62 +915,107 @@ public class SpinPlayer {
     })
   }
 
-  private func avAudioTimeFromDate(date: Date) -> AVAudioTime {
-    let outputFormat = playerNode.outputFormat(forBus: 0)
-    guard let lastRenderTime = playerNode.lastRenderTime else {
-      // Handle missing render time
-      let error = NSError(
-        domain: "fm.playola.PlayolaPlayer",
-        code: 500,
-        userInfo: [
-          NSLocalizedDescriptionKey:
-            "Could not get last render time from player node"
-        ]
+  /// Result of converting a wall-clock airtime into the player node's sample
+  /// timeline. `missingRenderTime` is true when the node had no `lastRenderTime`
+  /// (the caller reports it from the main actor).
+  private struct ScheduledTime {
+    let avAudioTime: AVAudioTime
+    let missingRenderTime: Bool
+  }
+
+  /// Pure conversion safe to run off the main thread. `outputFormat`/
+  /// `lastRenderTime` reads can block on the audio IO cycle, so this runs on the
+  /// serial control queue. Does no error reporting — see `ScheduledTime`.
+  private nonisolated static func scheduledTime(for date: Date, node: AVAudioPlayerNode)
+    -> ScheduledTime
+  {
+    let outputFormat = node.outputFormat(forBus: 0)
+    guard let lastRenderTime = node.lastRenderTime else {
+      return ScheduledTime(
+        avAudioTime: AVAudioTime(sampleTime: 0, atRate: outputFormat.sampleRate),
+        missingRenderTime: true
       )
-      Task {
-        await errorReporter.reportError(
-          error,
-          context: "Missing render time",
-          level: .warning
-        )
-      }
-      // Fallback to a reasonable default
-      return AVAudioTime(sampleTime: 0, atRate: outputFormat.sampleRate)
     }
 
     let now = lastRenderTime.sampleTime
     let secsUntilDate = date.timeIntervalSinceNow
-    return AVAudioTime(
-      sampleTime: now + Int64(secsUntilDate * outputFormat.sampleRate),
-      atRate: outputFormat.sampleRate
+    return ScheduledTime(
+      avAudioTime: AVAudioTime(
+        sampleTime: now + Int64(secsUntilDate * outputFormat.sampleRate),
+        atRate: outputFormat.sampleRate
+      ),
+      missingRenderTime: false
     )
+  }
+
+  /// Schedules `playerNode.play(at:)` for a future airtime, computing the sample
+  /// time and issuing the (potentially blocking) play off the main thread.
+  /// Skips the play if `epoch` was superseded before the block ran. Returns
+  /// whether the node was missing a render time so the caller can report.
+  private func playFuture(at scheduledDate: Date, epoch: Int) async -> Bool {
+    let node = playerNode
+    let epochLock = atomicEpoch
+    return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+      audioControlQueue.async {
+        guard epochLock.withLock({ $0 }) == epoch else {
+          continuation.resume(returning: false)
+          return
+        }
+        let scheduled = SpinPlayer.scheduledTime(for: scheduledDate, node: node)
+        node.play(at: scheduled.avAudioTime)
+        continuation.resume(returning: scheduled.missingRenderTime)
+      }
+    }
+  }
+
+  private func reportMissingRenderTime() {
+    let error = NSError(
+      domain: "fm.playola.PlayolaPlayer",
+      code: 500,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "Could not get last render time from player node"
+      ]
+    )
+    Task {
+      await errorReporter.reportError(
+        error,
+        context: "Missing render time",
+        level: .warning
+      )
+    }
   }
 
   // MARK: - Scheduled Playback
 
   /// schedule a future play from the beginning of the file
   /// Schedule playback to start at a specific time
-  public func schedulePlay(at scheduledDate: Date) {
+  public func schedulePlay(at scheduledDate: Date) async {
+    let epoch = beginPlayback()
     do {
-      try prepareAudioEngine(scheduledDate: scheduledDate)
+      try await prepareAudioEngine(scheduledDate: scheduledDate)
+      guard epoch == playbackEpoch else { return }
       try validateAudioFile()
-
-      // Scheduled plays always start from the top of the file
-      self.playbackStartOffset = 0
-
-      let avAudiotime = avAudioTimeFromDate(date: scheduledDate)
-      let scheduledSpinId = spin?.id
-
-      playerNode.play(at: avAudiotime)
-      setupNotificationTimer(scheduledDate: scheduledDate, scheduledSpinId: scheduledSpinId)
-
-      logScheduleComplete(scheduledDate: scheduledDate)
     } catch {
-      reportScheduleError(error)
+      if epoch == playbackEpoch { reportScheduleError(error) }
+      return
     }
+
+    // Scheduled plays always start from the top of the file
+    self.playbackStartOffset = 0
+
+    let scheduledSpinId = spin?.id
+    let missingRenderTime = await playFuture(at: scheduledDate, epoch: epoch)
+
+    // A stop()/clear() (or newer play) may have superseded us off-main.
+    guard epoch == playbackEpoch else { return }
+    if missingRenderTime { reportMissingRenderTime() }
+
+    setupNotificationTimer(scheduledDate: scheduledDate, scheduledSpinId: scheduledSpinId)
+    logScheduleComplete(scheduledDate: scheduledDate)
   }
 
-  private func prepareAudioEngine(scheduledDate: Date) throws {
+  private func prepareAudioEngine(scheduledDate: Date) async throws {
     os_log(
       "Scheduling play at %@",
       log: SpinPlayer.logger,
@@ -867,8 +1029,9 @@ public class SpinPlayer {
       "Audio session must be configured before calling schedulePlay — call ensureAudioSessionConfigured() first"
     )
     playolaMainMixer.configureAudioSession()
+    // Start the engine off the main thread to avoid blocking on AUIOClient_StartIO.
     if !engine.isRunning {
-      try engine.start()
+      try await playolaMainMixer.start()
     }
   }
 

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -672,7 +672,7 @@ public class SpinPlayer {
         return
       }
 
-      self.scheduleFades(spin)
+      await self.scheduleFades(spin)
       self.state = .loaded
       continuation.resume(returning: .success(localUrl))
     }
@@ -755,10 +755,10 @@ public class SpinPlayer {
 
   /// Install a one-shot tap to capture the first non-silent render on `trackMixer`,
   /// establishing `scheduledStartSample` so fades can be scheduled in the audio sample domain.
-  private func installStartTapIfNeeded(pendingFades: [(offset: Double, to: Float)]) {
+  private func installStartTapIfNeeded(pendingFades: [(offset: Double, to: Float)]) async {
     guard !startTapInstalled else { return }
     startTapInstalled = true
-    ensureEngineRunning()
+    await ensureEngineRunning()
     didCaptureStart = false
 
     trackMixer.installTap(onBus: 0, bufferSize: Constants.tapBufferSize, format: nil) {
@@ -767,11 +767,14 @@ public class SpinPlayer {
     }
   }
 
-  private func ensureEngineRunning() {
+  private func ensureEngineRunning() async {
     guard !engine.isRunning else { return }
+    playolaMainMixer.configureAudioSession()
     do {
-      playolaMainMixer.configureAudioSession()
-      try engine.start()
+      // Start off the main thread to avoid blocking on AUIOClient_StartIO if the
+      // engine was reset (e.g. by an audio-session interruption) since the
+      // off-main start in playNow/schedulePlay.
+      try await playolaMainMixer.start()
     } catch {
       os_log(
         "⚠️ Could not start engine before installing tap: %{public}@",
@@ -947,22 +950,31 @@ public class SpinPlayer {
     )
   }
 
+  /// Outcome of `playFuture`: either the play was skipped because the epoch was
+  /// superseded before the queue block ran, or it played (and we know whether
+  /// the node was missing a render time). Keeping these distinct avoids
+  /// conflating "skipped" with "played successfully" at the call site.
+  private enum FuturePlayOutcome {
+    case skipped
+    case played(missingRenderTime: Bool)
+  }
+
   /// Schedules `playerNode.play(at:)` for a future airtime, computing the sample
   /// time and issuing the (potentially blocking) play off the main thread.
-  /// Skips the play if `epoch` was superseded before the block ran. Returns
-  /// whether the node was missing a render time so the caller can report.
-  private func playFuture(at scheduledDate: Date, epoch: Int) async -> Bool {
+  /// Skips the play if `epoch` was superseded before the block ran.
+  private func playFuture(at scheduledDate: Date, epoch: Int) async -> FuturePlayOutcome {
     let node = playerNode
     let epochLock = atomicEpoch
-    return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+    return await withCheckedContinuation {
+      (continuation: CheckedContinuation<FuturePlayOutcome, Never>) in
       audioControlQueue.async {
         guard epochLock.withLock({ $0 }) == epoch else {
-          continuation.resume(returning: false)
+          continuation.resume(returning: .skipped)
           return
         }
         let scheduled = SpinPlayer.scheduledTime(for: scheduledDate, node: node)
         node.play(at: scheduled.avAudioTime)
-        continuation.resume(returning: scheduled.missingRenderTime)
+        continuation.resume(returning: .played(missingRenderTime: scheduled.missingRenderTime))
       }
     }
   }
@@ -1004,11 +1016,13 @@ public class SpinPlayer {
     self.playbackStartOffset = 0
 
     let scheduledSpinId = spin?.id
-    let missingRenderTime = await playFuture(at: scheduledDate, epoch: epoch)
+    let outcome = await playFuture(at: scheduledDate, epoch: epoch)
 
     // A stop()/clear() (or newer play) may have superseded us off-main.
     guard epoch == playbackEpoch else { return }
-    if missingRenderTime { reportMissingRenderTime() }
+    if case .played(let missingRenderTime) = outcome, missingRenderTime {
+      reportMissingRenderTime()
+    }
 
     setupNotificationTimer(scheduledDate: scheduledDate, scheduledSpinId: scheduledSpinId)
     logScheduleComplete(scheduledDate: scheduledDate)
@@ -1262,7 +1276,7 @@ public class SpinPlayer {
     self.state = .available
   }
 
-  public func scheduleFades(_ spin: Spin) {
+  public func scheduleFades(_ spin: Spin) async {
     // Convert Spin fades to offsets (seconds) relative to *this* playback start
     // If we started mid-file (playNow(from:)), shift fades left by that offset and drop past ones
     let fades: [(offset: Double, to: Float)] = spin.fades.compactMap { fade in
@@ -1280,7 +1294,7 @@ public class SpinPlayer {
     }
 
     // Otherwise, install a one-shot tap to capture the true start and then schedule.
-    installStartTapIfNeeded(pendingFades: fades)
+    await installStartTapIfNeeded(pendingFades: fades)
   }
 
   // MARK: - Timer Management

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -672,7 +672,7 @@ public class SpinPlayer {
         return
       }
 
-      await self.scheduleFades(spin)
+      self.scheduleFades(spin)
       self.state = .loaded
       continuation.resume(returning: .success(localUrl))
     }
@@ -755,10 +755,10 @@ public class SpinPlayer {
 
   /// Install a one-shot tap to capture the first non-silent render on `trackMixer`,
   /// establishing `scheduledStartSample` so fades can be scheduled in the audio sample domain.
-  private func installStartTapIfNeeded(pendingFades: [(offset: Double, to: Float)]) async {
+  private func installStartTapIfNeeded(pendingFades: [(offset: Double, to: Float)]) {
     guard !startTapInstalled else { return }
     startTapInstalled = true
-    await ensureEngineRunning()
+    ensureEngineRunning()
     didCaptureStart = false
 
     trackMixer.installTap(onBus: 0, bufferSize: Constants.tapBufferSize, format: nil) {
@@ -767,18 +767,25 @@ public class SpinPlayer {
     }
   }
 
-  private func ensureEngineRunning() async {
+  private func ensureEngineRunning() {
     guard !engine.isRunning else { return }
     playolaMainMixer.configureAudioSession()
-    do {
-      // Start off the main thread to avoid blocking on AUIOClient_StartIO if the
-      // engine was reset (e.g. by an audio-session interruption) since the
-      // off-main start in playNow/schedulePlay.
-      try await playolaMainMixer.start()
-    } catch {
-      os_log(
-        "⚠️ Could not start engine before installing tap: %{public}@",
-        log: SpinPlayer.logger, type: .error, String(describing: error))
+    // Start off the main thread (fire-and-forget) so we never block on
+    // AUIOClient_StartIO here. Installing the tap below doesn't require the
+    // engine to already be running — buffers flow once the async start lands.
+    // Kept synchronous (no await) on purpose: adding a suspension point between
+    // `startTapInstalled = true` and installTap would let a clear() interleave
+    // and orphan the tap. This path is only hit if the engine was reset (e.g. an
+    // audio-session interruption) after playNow/schedulePlay started it off-main.
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await self.playolaMainMixer.start()
+      } catch {
+        os_log(
+          "⚠️ Could not start engine before installing tap: %{public}@",
+          log: SpinPlayer.logger, type: .error, String(describing: error))
+      }
     }
   }
 
@@ -1276,7 +1283,7 @@ public class SpinPlayer {
     self.state = .available
   }
 
-  public func scheduleFades(_ spin: Spin) async {
+  public func scheduleFades(_ spin: Spin) {
     // Convert Spin fades to offsets (seconds) relative to *this* playback start
     // If we started mid-file (playNow(from:)), shift fades left by that offset and drop past ones
     let fades: [(offset: Double, to: Float)] = spin.fades.compactMap { fade in
@@ -1294,7 +1301,7 @@ public class SpinPlayer {
     }
 
     // Otherwise, install a one-shot tap to capture the true start and then schedule.
-    await installStartTapIfNeeded(pendingFades: fades)
+    installStartTapIfNeeded(pendingFades: fades)
   }
 
   // MARK: - Timer Management

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -15,7 +15,6 @@ import AudioToolbox
 import Foundation
 import PlayolaCore
 import os
-import os.log
 
 #if os(iOS)
   import QuartzCore

--- a/Sources/PlayolaPlayer/Player/SpinPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/SpinPlayer.swift
@@ -61,6 +61,9 @@ public class SpinPlayer {
   public var spin: Spin? {
     didSet { setClearTimer(spin) }
   }
+  /// The PlayolaStationPlayer play() generation that scheduled this player.
+  /// Used to ignore playback callbacks from a superseded session.
+  var playGeneration: Int = 0
   public weak var delegate: SpinPlayerDelegate?
   public var localUrl: URL? { return currentFile?.url }
 

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -171,6 +171,23 @@ struct PlayolaStationPlayerScheduleRetryTests {
 
     #expect(session.requestCallCount == 1)
   }
+
+  // A cancellation thrown by the transport (a routine stop() during the
+  // in-flight initial fetch) takes the cancellation branch in fetchScheduleOnce:
+  // it is not reported as a production error and is not retried — it fails fast
+  // and propagates so play() can treat it as a cancellation, not a terminal error.
+  @Test("A cancelled URLError fails fast without retrying")
+  func testCancelledURLErrorFailsFast() async throws {
+    let session = MockURLSession()
+    session.errorToThrow = URLError(.cancelled)
+    let player = makePlayer(session: session)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+    }
+
+    #expect(session.requestCallCount == 1)
+  }
 }
 
 /// Records the sequence of state transitions reported via the delegate.

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -88,27 +88,52 @@ struct PlayolaStationPlayerScheduleRetryTests {
     }
   }
 
-  @Test("A lingering schedulingTask is cancelled when play() fails terminally")
-  func testFailedPlayCancelsLingeringSchedulingTask() async throws {
+  @Test("A failed play() does not tear down a prior session's scheduling loop")
+  func testFailedPlayDoesNotCancelPriorSchedulingTask() async throws {
     let session = MockURLSession()
     for _ in 0..<10 { session.addResponse(statusCode: 404) }
     let player = makePlayer(session: session)
 
-    // Simulate a poll loop left running by a prior successful session. If it
-    // survives a failed play(), it can re-schedule a spin and flip .error
-    // back to .playing.
-    let lingering = Task<Void, Never> {
+    // A poll loop owned by a prior successful session. A failed later play()
+    // must not reach across and cancel work it did not start (Marge #3); the
+    // generation token — not a force-cancel — is what protects the new state.
+    let priorLoop = Task<Void, Never> {
       while !Task.isCancelled {
         try? await Task.sleep(nanoseconds: 50_000_000)
       }
     }
-    player.schedulingTask = lingering
+    player.schedulingTask = priorLoop
 
     await #expect(throws: (any Error).self) {
       try await player.play(stationId: "station-1")
     }
 
-    #expect(lingering.isCancelled)
+    #expect(!priorLoop.isCancelled)
+    priorLoop.cancel()
+  }
+
+  @Test("A stale spin's startedPlaying does not override a newer terminal state")
+  func testStaleSpinDoesNotOverrideState() async throws {
+    let session = MockURLSession()
+    for _ in 0..<10 { session.addResponse(statusCode: 404) }
+    let player = makePlayer(session: session)
+
+    // Land on .error as the current generation.
+    await #expect(throws: (any Error).self) {
+      try await player.play(stationId: "station-1")
+    }
+
+    // A spin player scheduled by an OLDER generation reports it started.
+    // Cooperative cancellation can't prevent this callback, so the generation
+    // token must (Marge #1).
+    let staleSpinPlayer = SpinPlayer(delegate: player)
+    staleSpinPlayer.playGeneration = player.playGeneration - 1
+    player.player(staleSpinPlayer, startedPlaying: Spin.mock)
+
+    if case .error = player.state {
+    } else {
+      Issue.record("Stale spin overrode terminal state: \(player.state)")
+    }
   }
 
   @Test("A cancelled download is treated as cancellation, not a terminal error")
@@ -121,6 +146,34 @@ struct PlayolaStationPlayerScheduleRetryTests {
     #expect(player.isCancellation(CancellationError()))
     #expect(player.isCancellation(URLError(.cancelled)))
     #expect(!player.isCancellation(StationPlayerError.networkError("HTTP error: 500")))
+  }
+
+  // MARK: - Marge #2: retry classification limited to connectivity errors
+
+  @Test("A connectivity URLError (timed out) is retried with backoff")
+  func testConnectivityURLErrorIsRetried() async throws {
+    let session = MockURLSession()
+    session.errorToThrow = URLError(.timedOut)
+    let player = makePlayer(session: session)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+    }
+
+    #expect(session.requestCallCount == 4)  // initial + 3 retries
+  }
+
+  @Test("A non-connectivity URLError (bad URL) fails fast without retrying")
+  func testNonConnectivityURLErrorFailsFast() async throws {
+    let session = MockURLSession()
+    session.errorToThrow = URLError(.badURL)
+    let player = makePlayer(session: session)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+    }
+
+    #expect(session.requestCallCount == 1)
   }
 }
 

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+@testable import PlayolaPlayer
+
+@MainActor
+struct PlayolaStationPlayerScheduleRetryTests {
+
+  /// Encodes the mock schedule into the same wire format the server returns
+  /// (a top-level array of spins) so `getUpdatedSchedule` can decode it.
+  private func validScheduleData() throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .formatted(.iso8601Full)
+    return try encoder.encode(Schedule.mock.spins)
+  }
+
+  private func makePlayer(session: MockURLSession) -> PlayolaStationPlayer {
+    let player = PlayolaStationPlayer(
+      fileDownloadManager: MockFileDownloadManager(),
+      urlSession: session)
+    player.scheduleRetryBaseDelay = 0  // keep backoff instant in tests
+    return player
+  }
+
+  // MARK: - Issue 1: bounded backoff for the initial schedule fetch
+
+  @Test("Retries a transient 500 then succeeds")
+  func testRetriesTransientThenSucceeds() async throws {
+    let session = MockURLSession()
+    session.addResponse(statusCode: 500)
+    session.addResponse(statusCode: 500)
+    session.addResponse(data: try validScheduleData(), statusCode: 200)
+    let player = makePlayer(session: session)
+
+    let schedule = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+
+    #expect(session.requestCallCount == 3)
+    #expect(!schedule.spins.isEmpty)
+  }
+
+  @Test("Gives up and throws after exhausting retries on persistent 500")
+  func testGivesUpAfterMaxRetries() async throws {
+    let session = MockURLSession()
+    for _ in 0..<10 { session.addResponse(statusCode: 500) }
+    let player = makePlayer(session: session)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+    }
+
+    // initial attempt + 3 retries
+    #expect(session.requestCallCount == 4)
+  }
+
+  @Test("Does not retry a 404 (permanent) error")
+  func testDoesNotRetryClientError() async throws {
+    let session = MockURLSession()
+    for _ in 0..<10 { session.addResponse(statusCode: 404) }
+    let player = makePlayer(session: session)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await player.getUpdatedScheduleWithRetry(stationId: "station-1")
+    }
+
+    #expect(session.requestCallCount == 1)
+  }
+
+  // MARK: - Issue 2: terminal state emitted from play()
+
+  @Test("play emits .loading then .error when the schedule fetch fails")
+  func testPlayEmitsErrorStateOnFailure() async throws {
+    let session = MockURLSession()
+    for _ in 0..<10 { session.addResponse(statusCode: 404) }
+    let player = makePlayer(session: session)
+
+    let recorder = StateRecorder()
+    player.delegate = recorder
+
+    await #expect(throws: (any Error).self) {
+      try await player.play(stationId: "station-1")
+    }
+
+    #expect(recorder.tags.contains("loading"))
+    #expect(recorder.tags.last == "error")
+    if case .error = player.state {
+    } else {
+      Issue.record("Expected player.state to be .error, got \(player.state)")
+    }
+  }
+}
+
+/// Records the sequence of state transitions reported via the delegate.
+@MainActor
+private final class StateRecorder: PlayolaStationPlayerDelegate {
+  var tags: [String] = []
+
+  nonisolated func player(
+    _ player: PlayolaStationPlayer,
+    playerStateDidChange state: PlayolaStationPlayer.State
+  ) {
+    let tag: String
+    switch state {
+    case .loading: tag = "loading"
+    case .playing: tag = "playing"
+    case .idle: tag = "idle"
+    case .error: tag = "error"
+    }
+    MainActor.assumeIsolated { tags.append(tag) }
+  }
+}

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -112,28 +112,24 @@ struct PlayolaStationPlayerScheduleRetryTests {
     priorLoop.cancel()
   }
 
-  @Test("A stale spin's startedPlaying does not override a newer terminal state")
-  func testStaleSpinDoesNotOverrideState() async throws {
+  @Test("Playback callbacks from a superseded generation are gated out")
+  func testGenerationGateRejectsStaleWork() async throws {
     let session = MockURLSession()
     for _ in 0..<10 { session.addResponse(statusCode: 404) }
     let player = makePlayer(session: session)
 
-    // Land on .error as the current generation.
+    // A failed play() still bumps the generation (last play() wins).
     await #expect(throws: (any Error).self) {
       try await player.play(stationId: "station-1")
     }
 
-    // A spin player scheduled by an OLDER generation reports it started.
-    // Cooperative cancellation can't prevent this callback, so the generation
-    // token must (Marge #1).
-    let staleSpinPlayer = SpinPlayer(delegate: player)
-    staleSpinPlayer.playGeneration = player.playGeneration - 1
-    player.player(staleSpinPlayer, startedPlaying: Spin.mock)
-
-    if case .error = player.state {
-    } else {
-      Issue.record("Stale spin overrode terminal state: \(player.state)")
-    }
+    // `player(_:startedPlaying:)` admits a spin only when its generation is
+    // current. An older generation — e.g. a spin scheduled by a prior session —
+    // is rejected, which is what stops it overwriting the terminal state
+    // (Marge #1). Asserted via the gate directly so the test doesn't construct
+    // a CoreAudio-backed SpinPlayer (which hangs headless CI).
+    #expect(player.isCurrentGeneration(player.playGeneration))
+    #expect(!player.isCurrentGeneration(player.playGeneration - 1))
   }
 
   @Test("A cancelled download is treated as cancellation, not a terminal error")

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -87,6 +87,29 @@ struct PlayolaStationPlayerScheduleRetryTests {
       Issue.record("Expected player.state to be .error, got \(player.state)")
     }
   }
+
+  @Test("A lingering schedulingTask is cancelled when play() fails terminally")
+  func testFailedPlayCancelsLingeringSchedulingTask() async throws {
+    let session = MockURLSession()
+    for _ in 0..<10 { session.addResponse(statusCode: 404) }
+    let player = makePlayer(session: session)
+
+    // Simulate a poll loop left running by a prior successful session. If it
+    // survives a failed play(), it can re-schedule a spin and flip .error
+    // back to .playing.
+    let lingering = Task<Void, Never> {
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: 50_000_000)
+      }
+    }
+    player.schedulingTask = lingering
+
+    await #expect(throws: (any Error).self) {
+      try await player.play(stationId: "station-1")
+    }
+
+    #expect(lingering.isCancelled)
+  }
 }
 
 /// Records the sequence of state transitions reported via the delegate.

--- a/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
+++ b/Tests/PlayolaPlayerTests/PlayolaStationPlayerScheduleRetryTests.swift
@@ -110,6 +110,18 @@ struct PlayolaStationPlayerScheduleRetryTests {
 
     #expect(lingering.isCancelled)
   }
+
+  @Test("A cancelled download is treated as cancellation, not a terminal error")
+  func testDownloadCancelledIsNotTerminalError() async throws {
+    let player = makePlayer(session: MockURLSession())
+
+    // Thrown by scheduleSpin when stop() cancels an in-flight download during a
+    // station switch — must not flip the new play()'s .loading state to .error.
+    #expect(player.isCancellation(FileDownloadError.downloadCancelled))
+    #expect(player.isCancellation(CancellationError()))
+    #expect(player.isCancellation(URLError(.cancelled)))
+    #expect(!player.isCancellation(StationPlayerError.networkError("HTTP error: 500")))
+  }
 }
 
 /// Records the sequence of state transitions reported via the delegate.

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
@@ -13,9 +13,17 @@ final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
   var requestCallCount = 0
   var lastRequest: URLRequest?
 
+  /// When set, every call throws this error (simulating a transport-level
+  /// failure such as a `URLError`) instead of returning a response.
+  var errorToThrow: Error?
+
   func data(for request: URLRequest) async throws -> (Data, URLResponse) {
     requestCallCount += 1
     lastRequest = request
+
+    if let errorToThrow {
+      throw errorToThrow
+    }
 
     if responses.isEmpty {
       // Default successful response


### PR DESCRIPTION
## Changes

- #96 fix: run SpinPlayer audio control off the main thread to fix App Hangs
- #95 fix: backoff + terminal error state for initial schedule fetch
- docs: document playNow/schedulePlay async signature change as source-breaking

This release ships the `0.19.0` CHANGELOG section. See `CHANGELOG.md` for full
notes, including the source-breaking changes (`State.error` case; `playNow` /
`schedulePlay` now `async`).

## Version Bump

- Previous tag on main: 0.17.1
- New: 0.19.0
- Bump type: minor (new features + source-breaking API changes, pre-1.0)

> Note: `main`'s CHANGELOG already carries a `## 0.18.0` section, but no `0.18.0`
> git tag was ever created (main is currently at tag `0.17.1`). This release
> continues the CHANGELOG numbering at `0.19.0`. The missing `0.18.0` tag is a
> pre-existing inconsistency to decide on separately.

## After Merge

Tag main with `0.19.0`:

\`\`\`bash
git checkout main && git pull
git tag 0.19.0
git push origin 0.19.0
\`\`\`