### PR TITLE
fix(sdk): generation-gate + .error state in engine-config recovery

### DIFF
--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -189,6 +189,7 @@ final public class PlayolaStationPlayer: ObservableObject {
   /// True once the engine-config-change observer has been registered (lazily,
   /// on first playback) so we register it exactly once.
   private var engineConfigObserverRegistered = false
+  private var engineConfigObserver: (any NSObjectProtocol)?
 
   /// Registers the AVAudioEngineConfigurationChange observer, scoped to the
   /// SDK's OWN engine. AVAudioEngine stops itself on a hardware/format/route
@@ -204,12 +205,19 @@ final public class PlayolaStationPlayer: ObservableObject {
   private func registerEngineConfigObserverIfNeeded() {
     guard !engineConfigObserverRegistered else { return }
     engineConfigObserverRegistered = true
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(handleAudioEngineConfigurationChange(_:)),
-      name: .AVAudioEngineConfigurationChange,
-      object: mainMixer.engine
-    )
+    // Deliver on the main queue: AVAudioEngineConfigurationChange fires on an
+    // unspecified thread, and the handler reads @MainActor state (isSuspended,
+    // isPlaying, stationId, playGeneration) synchronously before hopping into a
+    // Task. `queue: .main` guarantees those reads run on the main actor.
+    engineConfigObserver = NotificationCenter.default.addObserver(
+      forName: .AVAudioEngineConfigurationChange,
+      object: mainMixer.engine,
+      queue: .main
+    ) { [weak self] notification in
+      MainActor.assumeIsolated {
+        self?.handleAudioEngineConfigurationChange(notification)
+      }
+    }
   }
 
   private static let logger = OSLog(
@@ -947,9 +955,10 @@ final public class PlayolaStationPlayer: ObservableObject {
   /// has paused for an interruption (the host drives resume then). Only acts
   /// while actively playing; re-syncs to the live wall clock via play().
   ///
-  /// Internal (not public): it's a notification selector target, not host API —
-  /// the host never calls it. `@objc` is required for `#selector`.
-  @objc func handleAudioEngineConfigurationChange(_ notification: Notification) {
+  /// Internal: delivered on the main queue from a block observer (see
+  /// registerEngineConfigObserverIfNeeded), so it runs on the main actor. Not
+  /// host API — the host never calls it.
+  func handleAudioEngineConfigurationChange(_ notification: Notification) {
     os_log("Audio engine configuration changed", log: PlayolaStationPlayer.logger, type: .info)
     guard !isSuspended, isPlaying, let stationToRecover = stationId else { return }
     // Snapshot the recovery attempt: stationToRecover + generation together. Any
@@ -962,16 +971,17 @@ final public class PlayolaStationPlayer: ObservableObject {
         try await mainMixer.restartEngine()
       } catch {
         // Surface via state (mirrors resumeAfterInterruption) so a host driving
-        // UI from $state isn't left on a stale .playing with dead audio — but
-        // only if a host stop()/play() hasn't superseded us during the restart.
+        // UI from $state isn't left on a stale .playing with dead audio — and
+        // report — but only if a host stop()/play() hasn't superseded us during
+        // the restart (a superseded recovery is moot; don't add Sentry noise).
         if generation == playGeneration {
           state = .error(
             .playbackError(
               "Failed to recover audio engine after configuration change: "
                 + error.localizedDescription))
+          await errorReporter.reportError(
+            error, context: "Failed to recover engine after configuration change", level: .error)
         }
-        await errorReporter.reportError(
-          error, context: "Failed to recover engine after configuration change", level: .error)
         return
       }
       // A host stop()/play() during restartEngine took over — don't override it.

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -952,11 +952,34 @@ final public class PlayolaStationPlayer: ObservableObject {
   @objc func handleAudioEngineConfigurationChange(_ notification: Notification) {
     os_log("Audio engine configuration changed", log: PlayolaStationPlayer.logger, type: .info)
     guard !isSuspended, isPlaying, let stationToRecover = stationId else { return }
+    // Snapshot the recovery attempt: stationToRecover + generation together. Any
+    // host stop()/play() after this point bumps playGeneration and invalidates
+    // the recovery — we must not override the host's explicit choice (same
+    // supersession discipline resumeAfterInterruption() uses).
+    let generation = playGeneration
     Task { @MainActor in
       do {
         try await mainMixer.restartEngine()
+      } catch {
+        // Surface via state (mirrors resumeAfterInterruption) so a host driving
+        // UI from $state isn't left on a stale .playing with dead audio — but
+        // only if a host stop()/play() hasn't superseded us during the restart.
+        if generation == playGeneration {
+          state = .error(
+            .playbackError(
+              "Failed to recover audio engine after configuration change: "
+                + error.localizedDescription))
+        }
+        await errorReporter.reportError(
+          error, context: "Failed to recover engine after configuration change", level: .error)
+        return
+      }
+      // A host stop()/play() during restartEngine took over — don't override it.
+      guard generation == playGeneration else { return }
+      do {
         try await play(stationId: stationToRecover)
       } catch {
+        // play() publishes .error itself on terminal failure when still current.
         await errorReporter.reportError(
           error, context: "Failed to recover engine after configuration change", level: .error)
       }


### PR DESCRIPTION
Addresses the 3 P1 threads from the **0.20.0 release PR (#99)** re-review — all on `handleAudioEngineConfigurationChange`. They're the same supersession + state-consistency patterns already applied to `resumeAfterInterruption()`; this carries them into the engine-recovery handler.

## Fixes
1. **Generation gate (threads on lines 963/964).** The recovery `Task` called `play(stationId: stationToRecover)` after `restartEngine()` with no supersession check. A host `stop()`/`play(other)` during the ~100–200ms restart would be clobbered: the recovery would revive a stopped station or override the host's explicit station switch. Now snapshots `playGeneration` with `stationToRecover` and `guard generation == playGeneration` before `play()` — identical to `resumeAfterInterruption()`.
2. **`.error` on restart failure (line 963 thread).** A `restartEngine()` throw previously only went to Sentry; `state` stayed `.playing` with dead audio. Now publishes `state = .error(...)` (gated on generation) so a host driving UI from `$state` sees the failure — mirrors `resumeAfterInterruption()`.

## Testing
- `swift test`: **99 tests** pass (local + `CI=true`). Build / SwiftLint strict / swift-format clean.
- The recovery path calls `restartEngine()`/`play()` (real CoreAudio / resolves `.shared`), so per the no-CoreAudio test rule it's inspection-verified; the synchronous guard is covered by the existing engine-config tests.

Merges to `develop`; release PR #99 (`develop→main`) picks it up before the `0.20.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)