### PR TITLE
feat(sdk): add Airing.startTime/endTime on-air window (optional, additive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to PlayolaPlayer are documented here. This project follows
 which Swift Package Manager consumers pin to. Pre-1.0, breaking changes bump the
 minor version.
 
+## 0.20.1
+
+### Added
+
+- **`Airing.startTime` / `Airing.endTime` — the show's real on-air window.** Every
+  spin returned by `GET /v1/stations/{stationId}/schedule` now carries these two
+  fields on its nested `airing` object. `startTime` is the real moment the show
+  goes on air (`MIN(spin.airtime)` across the airing's spins, accounting for the
+  "lead gap" where preceding content pushes the show later than its slot);
+  `endTime` is the real moment it goes off air (`MAX(spin.endOfMessageTime)`,
+  floored at `airtime + episode.durationMS`). Both are optional ISO-8601 UTC
+  dates — present only on airings from the schedule feed and `nil` elsewhere — so
+  the change is additive and source-compatible. `airtime` (the nominal slot) is
+  unchanged. Downstream apps can drive a real-time "next show in ~N min" countdown
+  off `endTime`. Also available on the 0.19.x line as 0.19.1.
+
 ## 0.20.0
 
 This release makes the **host app the sole owner of the `AVAudioSession`.** The

--- a/Sources/PlayolaCore/Models/Airing.swift
+++ b/Sources/PlayolaCore/Models/Airing.swift
@@ -18,6 +18,20 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
   public let episode: Episode?
   public let station: Station?
 
+  /// The real moment the show goes on air (`MIN(spin.airtime)` across the airing's spins).
+  ///
+  /// Accounts for the "lead gap" where preceding content pushes the show later than its
+  /// nominal `airtime` slot. Present only on airings sourced from the schedule feed;
+  /// `nil` for airings sourced elsewhere.
+  public let startTime: Date?
+
+  /// The real moment the show goes off air (`MAX(spin.endOfMessageTime)`, floored at
+  /// `airtime + episode.durationMS`).
+  ///
+  /// Present only on airings sourced from the schedule feed; `nil` for airings sourced
+  /// elsewhere.
+  public let endTime: Date?
+
   public init(
     id: String,
     episodeId: String,
@@ -26,7 +40,9 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
     createdAt: Date,
     updatedAt: Date,
     episode: Episode? = nil,
-    station: Station? = nil
+    station: Station? = nil,
+    startTime: Date? = nil,
+    endTime: Date? = nil
   ) {
     self.id = id
     self.episodeId = episodeId
@@ -36,6 +52,8 @@ public struct Airing: Codable, Sendable, Equatable, Hashable, Identifiable {
     self.updatedAt = updatedAt
     self.episode = episode
     self.station = station
+    self.startTime = startTime
+    self.endTime = endTime
   }
 }
 

--- a/Sources/PlayolaCore/Models/Airing.swift
+++ b/Sources/PlayolaCore/Models/Airing.swift
@@ -79,7 +79,9 @@ extension Airing {
     createdAt: Date? = nil,
     updatedAt: Date? = nil,
     episode: Episode?? = nil,
-    station: Station?? = nil
+    station: Station?? = nil,
+    startTime: Date?? = nil,
+    endTime: Date?? = nil
   ) -> Airing {
     let mock = Self.mock
     return Airing(
@@ -90,7 +92,9 @@ extension Airing {
       createdAt: createdAt ?? mock.createdAt,
       updatedAt: updatedAt ?? mock.updatedAt,
       episode: episode ?? mock.episode,
-      station: station ?? mock.station
+      station: station ?? mock.station,
+      startTime: startTime ?? mock.startTime,
+      endTime: endTime ?? mock.endTime
     )
   }
 }

--- a/Tests/PlayolaCoreTests/AiringTests.swift
+++ b/Tests/PlayolaCoreTests/AiringTests.swift
@@ -60,6 +60,46 @@ struct AiringTests {
     #expect(airing.endTime == nil)
   }
 
+  @Test("Airing decodes with only startTime present (fields are independently optional)")
+  func testAiringDecodesWithOnlyStartTime() throws {
+    let json = """
+      {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "episodeId": "22222222-2222-2222-2222-222222222222",
+          "stationId": "33333333-3333-3333-3333-333333333333",
+          "airtime": "2025-02-15T15:00:00.000Z",
+          "startTime": "2025-02-15T15:00:12.000Z",
+          "createdAt": "2025-02-14T10:00:00.000Z",
+          "updatedAt": "2025-02-14T10:00:00.000Z"
+      }
+      """
+    let decoder = JSONDecoderWithIsoFull()
+    let airing = try decoder.decode(Airing.self, from: json.data(using: .utf8)!)
+
+    #expect(airing.startTime == DateFormatter.iso8601Full.date(from: "2025-02-15T15:00:12.000Z"))
+    #expect(airing.endTime == nil)
+  }
+
+  @Test("Airing decodes with only endTime present (fields are independently optional)")
+  func testAiringDecodesWithOnlyEndTime() throws {
+    let json = """
+      {
+          "id": "11111111-1111-1111-1111-111111111111",
+          "episodeId": "22222222-2222-2222-2222-222222222222",
+          "stationId": "33333333-3333-3333-3333-333333333333",
+          "airtime": "2025-02-15T15:00:00.000Z",
+          "endTime": "2025-02-15T15:42:30.000Z",
+          "createdAt": "2025-02-14T10:00:00.000Z",
+          "updatedAt": "2025-02-14T10:00:00.000Z"
+      }
+      """
+    let decoder = JSONDecoderWithIsoFull()
+    let airing = try decoder.decode(Airing.self, from: json.data(using: .utf8)!)
+
+    #expect(airing.startTime == nil)
+    #expect(airing.endTime == DateFormatter.iso8601Full.date(from: "2025-02-15T15:42:30.000Z"))
+  }
+
   @Test("Spin with a nested airing carrying the on-air window decodes end-to-end")
   func testSpinDecodesNestedAiringOnAirWindow() throws {
     let endTime = DateFormatter.iso8601Full.date(from: "2025-02-15T15:42:30.000Z")!

--- a/Tests/PlayolaCoreTests/AiringTests.swift
+++ b/Tests/PlayolaCoreTests/AiringTests.swift
@@ -1,0 +1,90 @@
+//
+//  AiringTests.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 6/27/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PlayolaCore
+
+struct AiringTests {
+  private static let airingWithOnAirWindowJSON = """
+    {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "episodeId": "22222222-2222-2222-2222-222222222222",
+        "stationId": "33333333-3333-3333-3333-333333333333",
+        "airtime": "2025-02-15T15:00:00.000Z",
+        "startTime": "2025-02-15T15:00:12.000Z",
+        "endTime": "2025-02-15T15:42:30.000Z",
+        "createdAt": "2025-02-14T10:00:00.000Z",
+        "updatedAt": "2025-02-14T10:00:00.000Z"
+    }
+    """
+
+  private static let airingWithoutOnAirWindowJSON = """
+    {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "episodeId": "22222222-2222-2222-2222-222222222222",
+        "stationId": "33333333-3333-3333-3333-333333333333",
+        "airtime": "2025-02-15T15:00:00.000Z",
+        "createdAt": "2025-02-14T10:00:00.000Z",
+        "updatedAt": "2025-02-14T10:00:00.000Z"
+    }
+    """
+
+  @Test("Airing decodes startTime and endTime from JSON")
+  func testAiringDecodesOnAirWindow() throws {
+    let decoder = JSONDecoderWithIsoFull()
+    let airing = try decoder.decode(
+      Airing.self, from: Self.airingWithOnAirWindowJSON.data(using: .utf8)!)
+
+    let expectedStart = DateFormatter.iso8601Full.date(from: "2025-02-15T15:00:12.000Z")
+    let expectedEnd = DateFormatter.iso8601Full.date(from: "2025-02-15T15:42:30.000Z")
+
+    #expect(airing.startTime == expectedStart)
+    #expect(airing.endTime == expectedEnd)
+    // airtime remains the nominal slot, independent of the real on-air window
+    #expect(airing.airtime == DateFormatter.iso8601Full.date(from: "2025-02-15T15:00:00.000Z"))
+  }
+
+  @Test("Airing decodes with startTime and endTime absent (backward compatible)")
+  func testAiringDecodesWithoutOnAirWindow() throws {
+    let decoder = JSONDecoderWithIsoFull()
+    let airing = try decoder.decode(
+      Airing.self, from: Self.airingWithoutOnAirWindowJSON.data(using: .utf8)!)
+
+    #expect(airing.startTime == nil)
+    #expect(airing.endTime == nil)
+  }
+
+  @Test("Spin with a nested airing carrying the on-air window decodes end-to-end")
+  func testSpinDecodesNestedAiringOnAirWindow() throws {
+    let endTime = DateFormatter.iso8601Full.date(from: "2025-02-15T15:42:30.000Z")!
+    let startTime = DateFormatter.iso8601Full.date(from: "2025-02-15T15:00:12.000Z")!
+
+    let airing = Airing(
+      id: "11111111-1111-1111-1111-111111111111",
+      episodeId: "22222222-2222-2222-2222-222222222222",
+      stationId: "33333333-3333-3333-3333-333333333333",
+      airtime: DateFormatter.iso8601Full.date(from: "2025-02-15T15:00:00.000Z")!,
+      createdAt: DateFormatter.iso8601Full.date(from: "2025-02-14T10:00:00.000Z")!,
+      updatedAt: DateFormatter.iso8601Full.date(from: "2025-02-14T10:00:00.000Z")!,
+      startTime: startTime,
+      endTime: endTime)
+
+    let spin = Spin.mockWith(airing: airing)
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .formatted(.iso8601Full)
+    let data = try encoder.encode(spin)
+
+    let decoder = JSONDecoderWithIsoFull()
+    let decoded = try decoder.decode(Spin.self, from: data)
+
+    #expect(decoded.airing?.startTime == startTime)
+    #expect(decoded.airing?.endTime == endTime)
+  }
+}


### PR DESCRIPTION
## Summary

Adds the show's real **on-air window** to the `Airing` model so downstream apps can drive a real-time "Prize Giveaway in the next ~40 min" countdown off the actual show end time.

The schedule feed (`GET /v1/stations/{stationId}/schedule`) now includes two new fields on every spin's nested `airing` object:

- **`startTime`** — the real moment the show goes on air = `MIN(spin.airtime)` across the airing's spins (accounts for the "lead gap" where preceding content pushes the show later than its nominal slot).
- **`endTime`** — the real moment the show goes off air = `MAX(spin.endOfMessageTime)`, floored at `airtime + episode.durationMS`.

Both are optional ISO-8601 UTC dates decoded via `JSONDecoderWithIsoFull`. They are present only on airings from the schedule feed and absent elsewhere, so they decode to `nil` when missing. `airtime` (the nominal slot) is unchanged.

## Why additive / non-breaking

- Added as trailing memberwise-init params with `= nil` defaults → every existing call site stays source-compatible.
- `Codable`/`Equatable`/`Hashable` are synthesized; adding optional `let`s is additive.
- SemVer-non-breaking → **patch-eligible**.

## Tests

New `AiringTests.swift` (swift-testing, using the package's `JSONDecoderWithIsoFull`):
1. JSON with `startTime`/`endTime` → both decode to the expected Dates (and `airtime` stays the nominal slot).
2. JSON without them → both `nil` (backward compatibility).
3. A `Spin` whose nested `airing` carries the fields decodes end-to-end (`spin.airing?.endTime` non-nil).

`swift build` clean, full suite (102 tests) green, `swiftlint` clean.

## Releases (already cut)

This shipped as patch releases on both lines, with **byte-identical** `Airing` changes:

- **`0.19.1`** (off `0.19.0`) — the version the app pins to for now.
- **`0.20.1`** (off `0.20.0`) — so the change isn't lost when consumers move up.

This PR forward-ports the same change (code + CHANGELOG) onto `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional airing window start and end timestamps (ISO-8601 UTC) for scheduled airtimes when sourced from the schedule feed.
  * These fields are available alongside existing airtime details and remain optional for backward compatibility.
* **Documentation**
  * Updated the changelog with how the new timestamps are represented and that the change is available on the supported release lines.
* **Tests**
  * Added coverage for decoding/encoding the new fields, including scenarios where either or both values are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->