### PR TITLE
fix(sdk): keep listening-session reporting alive during background audio

### DIFF
--- a/PlayolaPlayerExample/PlayolaPlayerExample/Info.plist
+++ b/PlayolaPlayerExample/PlayolaPlayerExample/Info.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -514,6 +514,32 @@ try session.setCategory(.playback, mode: .default, policy: .longFormAudio, optio
 try session.setActive(true)
 ```
 
+#### Background playback & listening reporting
+
+The SDK keeps its listening-session heartbeat alive with a playback-state-driven
+task, not a foreground timer, so reporting continues while the app is
+backgrounded **as long as the host keeps the app alive for background audio**.
+The host must:
+
+1. **Declare the `audio` background mode.** Add `UIBackgroundModes` → `audio`
+   to your `Info.plist`. Without it, iOS suspends the process on backgrounding,
+   the audio render thread stops, and no client code (heartbeat or `/end`) can
+   run — listening time is undercounted even though a few seconds of buffered
+   audio may still be audible.
+
+2. **Keep the `.playback` session active** (the launch-time setup above).
+
+3. **Never call `stop()` on backgrounding.** `stop()` means "playback is over":
+   it ends the listening session. Calling it from a scene/lifecycle hook
+   (`scenePhase == .background`, `didEnterBackground`, `willResignActive`) ends
+   the session while audio is still playing, which is exactly the undercount
+   this design avoids. Only call `stop()` on a real user stop or teardown.
+
+4. **Use `pauseForInterruption()` for real audio interruptions only** (calls,
+   other apps grabbing the session), not for app backgrounding. A pause ends
+   the listening session because audio is genuinely silent; backgrounding is not
+   a pause.
+
 #### Interruption handling
 
 Call `pauseForInterruption()` synchronously when an interruption begins and `resumeAfterInterruption()` asynchronously when it ends:

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -90,7 +90,12 @@ public class ListeningSessionReporter {
     // so observing it reported failed loads and ended sessions on backgrounding.
     // `$state` only says "playing"/"paused"/"idle", which is what listening is.
     stationPlayer.$state.sink { [weak self] state in
-      self?.handleStateChange(state)
+      // `state` is published from the @MainActor player; assume isolation so the
+      // handler runs synchronously on the main actor (preserving state order)
+      // without an async hop that could reorder rapid transitions.
+      MainActor.assumeIsolated {
+        self?.handleStateChange(state)
+      }
     }.store(in: &disposeBag)
   }
 
@@ -126,10 +131,16 @@ public class ListeningSessionReporter {
     // the moment we subscribe to `$state` lands here and is correctly ignored.
     guard currentSessionStationId != nil else { return }
     currentSessionStationId = nil
-    heartbeatTask?.cancel()
+    let previous = heartbeatTask
+    previous?.cancel()
     heartbeatTask = nil
     Task { [weak self] in
+      // Let the in-flight heartbeat POST finish first so `/end` is the last
+      // write and can't be re-extended by a heartbeat that lands after it.
+      await previous?.value
       guard let self else { return }
+      // A new `.playing` started while we were draining — don't end its session.
+      guard self.currentSessionStationId == nil else { return }
       do {
         try await self.endListeningSession()
       } catch {
@@ -217,10 +228,16 @@ public class ListeningSessionReporter {
   /// captured here, not re-read from `stationPlayer` each tick, so `stop()`
   /// clearing `stationId` can't race the final loop iteration. A serial
   /// POST-then-sleep loop keeps heartbeats from overlapping if a POST runs long.
+  ///
+  /// The new loop drains the previous one (`await previous?.value`) before its
+  /// first POST so a station switch can't let the old station's in-flight POST
+  /// land after the new station's — the heartbeats stay strictly ordered.
   private func startHeartbeat(stationId: String) {
-    heartbeatTask?.cancel()
+    let previous = heartbeatTask
+    previous?.cancel()
     let interval = heartbeatInterval
     heartbeatTask = Task { [weak self] in
+      await previous?.value
       while !Task.isCancelled {
         guard let self else { return }
         do {

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -50,7 +50,18 @@ public class ListeningSessionReporter {
   var deviceId: String? {
     return DeviceInfoProvider.identifierForVendor?.uuidString
   }
-  var timer: Timer?
+  /// Background-safe heartbeat. A long-lived Task (not a foreground RunLoop
+  /// `Timer`) so it keeps firing while the app is backgrounded and audio is
+  /// still rendering. Started from real `.playing` state, cancelled on a real
+  /// stop/pause — never tied to the UI/scene lifecycle.
+  var heartbeatTask: Task<Void, Never>?
+  /// Seconds between heartbeat POSTs. Each POST extends the backend session by
+  /// 10s, so the cadence must stay under that window. Internal so tests can
+  /// shrink it; production keeps the default.
+  var heartbeatInterval: TimeInterval = 10.0
+  /// The station of the currently-active session, or nil when none is active.
+  /// Doubles as the guard that stops a stray `.idle`/`.paused` from sending a
+  /// bogus `/end` when no session was ever started.
   var currentSessionStationId: String?
   var disposeBag = Set<AnyCancellable>()
   weak var stationPlayer: PlayolaStationPlayer?
@@ -74,46 +85,58 @@ public class ListeningSessionReporter {
     self.urlSession = urlSession
     self.baseURL = baseURL
 
-    stationPlayer.$stationId.sink { [weak self] stationId in
-      guard let self else { return }
-      if let stationId {
-        Task {
-          do {
-            try await self.reportOrExtendListeningSession(stationId)
-            self.startPeriodicNotifications()
-          } catch {
-            Task {
-              await self.errorReporter.reportError(
-                error,
-                context: "Failed to initiate listening session for station \(stationId)",
-                level: .warning
-              )
-            }
-          }
-        }
-      } else {
-        Task {
-          do {
-            try await self.endListeningSession()
-            self.stopPeriodicNotifications()
-          } catch {
-            // Just log the error but don't fail critically since this is cleanup
-            Task {
-              await self.errorReporter.reportError(
-                error,
-                context: "Failed to cleanly end listening session",
-                level: .warning
-              )
-            }
-          }
-        }
-      }
+    // Drive the session off real playback state, NOT off `stationId`/the UI
+    // lifecycle. `stationId` is set during `.loading` and cleared by `stop()`,
+    // so observing it reported failed loads and ended sessions on backgrounding.
+    // `$state` only says "playing"/"paused"/"idle", which is what listening is.
+    stationPlayer.$state.sink { [weak self] state in
+      self?.handleStateChange(state)
     }.store(in: &disposeBag)
   }
 
   deinit {
-    self.timer?.invalidate()
+    self.heartbeatTask?.cancel()
     disposeBag.removeAll()
+  }
+
+  /// Maps published playback state to session lifecycle. Start reporting only
+  /// once audio is actually playing; end only on a genuine stop/pause. `.loading`
+  /// is deliberately inert so a failed or aborted load never creates a session.
+  func handleStateChange(_ state: PlayolaStationPlayer.State) {
+    switch state {
+    case .playing(let spin):
+      startSession(stationId: spin.stationId)
+    case .paused, .idle, .error:
+      endSessionIfActive()
+    case .loading:
+      break
+    }
+  }
+
+  private func startSession(stationId: String) {
+    // Already reporting this station — a repeated `.playing` emission must not
+    // spin up a second heartbeat.
+    if currentSessionStationId == stationId, heartbeatTask != nil { return }
+    currentSessionStationId = stationId
+    startHeartbeat(stationId: stationId)
+  }
+
+  private func endSessionIfActive() {
+    // No active session — don't send a bogus `/end`. The initial `.idle` emitted
+    // the moment we subscribe to `$state` lands here and is correctly ignored.
+    guard currentSessionStationId != nil else { return }
+    currentSessionStationId = nil
+    heartbeatTask?.cancel()
+    heartbeatTask = nil
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await self.endListeningSession()
+      } catch {
+        await self.errorReporter.reportError(
+          error, context: "Failed to cleanly end listening session", level: .warning)
+      }
+    }
   }
 
   public func endListeningSession() async throws {
@@ -190,40 +213,30 @@ public class ListeningSessionReporter {
     }
   }
 
-  private func startPeriodicNotifications() {
-    self.timer = Timer.scheduledTimer(
-      withTimeInterval: 10.0, repeats: true,
-      block: { [weak self] _ in
+  /// Starts (or restarts) the heartbeat loop for `stationId`. The station id is
+  /// captured here, not re-read from `stationPlayer` each tick, so `stop()`
+  /// clearing `stationId` can't race the final loop iteration. A serial
+  /// POST-then-sleep loop keeps heartbeats from overlapping if a POST runs long.
+  private func startHeartbeat(stationId: String) {
+    heartbeatTask?.cancel()
+    let interval = heartbeatInterval
+    heartbeatTask = Task { [weak self] in
+      while !Task.isCancelled {
         guard let self else { return }
-        guard let stationId = self.stationPlayer?.stationId else {
-          let error = ListeningSessionError.invalidResponse(
-            "Missing stationId in periodic notification")
-          Task {
-            await self.errorReporter.reportError(error, level: .warning)
-          }
-          return
+        do {
+          try await self.reportOrExtendListeningSession(stationId)
+        } catch {
+          // Log and keep looping — the next tick retries.
+          await self.errorReporter.reportError(
+            error, context: "Failed periodic listening session update", level: .warning)
         }
-
-        Task {
-          do {
-            try await self.reportOrExtendListeningSession(stationId)
-          } catch {
-            // Log errors but continue running - we'll try again next interval
-            Task {
-              await self.errorReporter.reportError(
-                error,
-                context: "Failed periodic listening session update",
-                level: .warning
-              )
-            }
-          }
+        do {
+          try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        } catch {
+          return  // cancelled during sleep
         }
-      })
-  }
-
-  private func stopPeriodicNotifications() {
-    self.timer?.invalidate()
-    self.timer = nil
+      }
+    }
   }
 
   private func handleAuthenticationFailure(url: URL, requestBody: ListeningSessionRequest)

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -102,11 +102,17 @@ public class ListeningSessionReporter {
     // so observing it reported failed loads and ended sessions on backgrounding.
     // `$state` only says "playing"/"paused"/"idle", which is what listening is.
     stationPlayer.$state.sink { [weak self] state in
-      // `state` is published from the @MainActor player; assume isolation so the
-      // handler runs synchronously on the main actor (preserving state order)
-      // without an async hop that could reorder rapid transitions.
-      MainActor.assumeIsolated {
-        self?.handleStateChange(state)
+      // `state` is published from the @MainActor player, so delivery is on the
+      // main actor: handle it synchronously to preserve state order (an async
+      // hop could reorder rapid transitions). Guard with `isMainThread` so a
+      // contract violation degrades to a safe async hop instead of crashing the
+      // `MainActor.assumeIsolated` precondition.
+      if Thread.isMainThread {
+        MainActor.assumeIsolated {
+          self?.handleStateChange(state)
+        }
+      } else {
+        Task { @MainActor in self?.handleStateChange(state) }
       }
     }.store(in: &disposeBag)
   }

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -257,19 +257,30 @@ public class ListeningSessionReporter {
     let interval = heartbeatInterval
     let task = Task { [weak self] in
       await previous?.value
+      let intervalNanos = UInt64(interval * 1_000_000_000)
       while !Task.isCancelled {
         guard let self else { return }
+        // Time the sleep from the START of the POST so the cadence is `interval`,
+        // not `interval + network round-trip`. Otherwise under poor connectivity
+        // the gap between POSTs exceeds the backend's session window
+        // (endTime = lastPOST + 10s) and the session expires between heartbeats —
+        // re-introducing the undercount this fix targets.
+        let startNanos = DispatchTime.now().uptimeNanoseconds
         do {
           try await self.reportOrExtendListeningSession(stationId)
           // The backend now has a session for this device — `/end` is allowed.
           self.remoteSessionStarted = true
         } catch {
+          // A cancellation (real stop/switch) is not a failure — exit quietly.
+          if Task.isCancelled { return }
           // Log and keep looping — the next tick retries.
           await self.errorReporter.reportError(
             error, context: "Failed periodic listening session update", level: .warning)
         }
+        let elapsedNanos = DispatchTime.now().uptimeNanoseconds - startNanos
+        let remaining = intervalNanos > elapsedNanos ? intervalNanos - elapsedNanos : 0
         do {
-          try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+          try await Task.sleep(nanoseconds: remaining)
         } catch {
           return  // cancelled during sleep
         }

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -55,6 +55,11 @@ public class ListeningSessionReporter {
   /// still rendering. Started from real `.playing` state, cancelled on a real
   /// stop/pause — never tied to the UI/scene lifecycle.
   var heartbeatTask: Task<Void, Never>?
+  /// Tail of the serialized lifecycle chain — the most recent start OR end task.
+  /// Every new transition awaits this before its own network write, so reports
+  /// and `/end`s for a device stay strictly ordered even across a station
+  /// switch or a rapid stop→start (no POST can land out of order).
+  private var lifecycleTail: Task<Void, Never>?
   /// Seconds between heartbeat POSTs. Each POST extends the backend session by
   /// 10s, so the cadence must stay under that window. Internal so tests can
   /// shrink it; production keeps the default.
@@ -101,6 +106,7 @@ public class ListeningSessionReporter {
 
   deinit {
     self.heartbeatTask?.cancel()
+    self.lifecycleTail?.cancel()
     disposeBag.removeAll()
   }
 
@@ -131,12 +137,12 @@ public class ListeningSessionReporter {
     // the moment we subscribe to `$state` lands here and is correctly ignored.
     guard currentSessionStationId != nil else { return }
     currentSessionStationId = nil
-    let previous = heartbeatTask
-    previous?.cancel()
+    let previous = lifecycleTail
+    heartbeatTask?.cancel()
     heartbeatTask = nil
-    Task { [weak self] in
-      // Let the in-flight heartbeat POST finish first so `/end` is the last
-      // write and can't be re-extended by a heartbeat that lands after it.
+    let task = Task { [weak self] in
+      // Drain the prior lifecycle write first so `/end` is the last write and
+      // can't be re-extended by a heartbeat that lands after it.
       await previous?.value
       guard let self else { return }
       // A new `.playing` started while we were draining — don't end its session.
@@ -148,6 +154,7 @@ public class ListeningSessionReporter {
           error, context: "Failed to cleanly end listening session", level: .warning)
       }
     }
+    lifecycleTail = task
   }
 
   public func endListeningSession() async throws {
@@ -229,14 +236,15 @@ public class ListeningSessionReporter {
   /// clearing `stationId` can't race the final loop iteration. A serial
   /// POST-then-sleep loop keeps heartbeats from overlapping if a POST runs long.
   ///
-  /// The new loop drains the previous one (`await previous?.value`) before its
-  /// first POST so a station switch can't let the old station's in-flight POST
-  /// land after the new station's — the heartbeats stay strictly ordered.
+  /// The new loop drains the previous lifecycle write (`await previous?.value`,
+  /// where `previous` is the chain tail — a prior heartbeat OR a prior `/end`)
+  /// before its first POST, so no station's in-flight POST can land after a
+  /// newer transition. Heartbeats and `/end`s stay strictly ordered.
   private func startHeartbeat(stationId: String) {
-    let previous = heartbeatTask
-    previous?.cancel()
+    let previous = lifecycleTail
+    heartbeatTask?.cancel()
     let interval = heartbeatInterval
-    heartbeatTask = Task { [weak self] in
+    let task = Task { [weak self] in
       await previous?.value
       while !Task.isCancelled {
         guard let self else { return }
@@ -254,6 +262,8 @@ public class ListeningSessionReporter {
         }
       }
     }
+    heartbeatTask = task
+    lifecycleTail = task
   }
 
   private func handleAuthenticationFailure(url: URL, requestBody: ListeningSessionRequest)

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -68,6 +68,13 @@ public class ListeningSessionReporter {
   /// Doubles as the guard that stops a stray `.idle`/`.paused` from sending a
   /// bogus `/end` when no session was ever started.
   var currentSessionStationId: String?
+  /// True once a `/listeningSessions` POST has actually succeeded for the current
+  /// device session — i.e. the backend really created a session. Gates `/end` so
+  /// a `.playing` whose first POST failed (auth/network) or was aborted before it
+  /// landed never sends a `/end` for a session that doesn't exist server-side.
+  /// Sticky across a station switch (one continuous per-device session); reset
+  /// only when the session actually ends.
+  var remoteSessionStarted = false
   var disposeBag = Set<AnyCancellable>()
   weak var stationPlayer: PlayolaStationPlayer?
   var currentListeningSessionID: String?
@@ -147,6 +154,10 @@ public class ListeningSessionReporter {
       guard let self else { return }
       // A new `.playing` started while we were draining — don't end its session.
       guard self.currentSessionStationId == nil else { return }
+      // Never created a session server-side (first POST failed/was aborted) —
+      // there is nothing to end, so don't send a bogus `/end`.
+      guard self.remoteSessionStarted else { return }
+      self.remoteSessionStarted = false
       do {
         try await self.endListeningSession()
       } catch {
@@ -250,6 +261,8 @@ public class ListeningSessionReporter {
         guard let self else { return }
         do {
           try await self.reportOrExtendListeningSession(stationId)
+          // The backend now has a session for this device — `/end` is allowed.
+          self.remoteSessionStarted = true
         } catch {
           // Log and keep looping — the next tick retries.
           await self.errorReporter.reportError(

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -812,7 +812,8 @@ final public class PlayolaStationPlayer: ObservableObject {
   /// 1. Stops all playing audio
   /// 2. Cancels pending downloads
   /// 3. Clears the current schedule
-  /// 4. Reports the end of the listening session
+  /// 4. Goes `.idle`, which ends the listening session (the reporter observes
+  ///    `state`, so a real stop ends reporting — backgrounding does not).
   public func stop() {
     os_log("🛑 STOP called", log: PlayolaStationPlayer.logger, type: .info)
 

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -440,5 +440,56 @@ struct ListeningSessionTests {
       // Keeps `reporter` alive through the awaits and confirms the session cleared.
       #expect(reporter.currentSessionStationId == nil)
     }
+
+    @Test("rapid stop→switch: B's POST waits for A's in-flight POST to drain")
+    func switchWaitsForInflightDrain() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      // Hold the very first POST (station A) in flight until we release it.
+      let gate = TestGate()
+      session.beforeResponse = { _ in
+        if await gate.claimFirst() { await gate.waitUntilReleased() }
+      }
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-A")))
+      await waitUntil { session.requestCallCount >= 1 }  // A's POST is in flight (held)
+
+      reporter.handleStateChange(.idle)
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-B")))
+
+      // While A is held, B must not have POSTed — the chain enforces ordering.
+      try? await Task.sleep(nanoseconds: 150_000_000)
+      #expect(session.requestCallCount == 1)
+
+      await gate.release()
+
+      // B now proceeds, strictly after A. No /end on the switch.
+      await waitUntil { session.requestCallCount >= 2 }
+      #expect(session.requestedURLs.allSatisfy { !$0.absoluteString.hasSuffix("/end") })
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions")
+    }
   }
+}
+
+/// Lets a test hold the first mock request in flight and release it on demand,
+/// to assert ordering across concurrent reporter transitions.
+private actor TestGate {
+  private var claimed = false
+  private var released = false
+
+  func claimFirst() -> Bool {
+    if claimed { return false }
+    claimed = true
+    return true
+  }
+
+  func waitUntilReleased() async {
+    while !released { try? await Task.sleep(nanoseconds: 5_000_000) }
+  }
+
+  func release() { released = true }
 }

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -479,7 +479,8 @@ struct ListeningSessionTests {
       #expect(reporter.currentSessionStationId == nil)
     }
 
-    @Test("rapid stop→switch: B's POST waits for A's in-flight POST to drain")
+    @Test(
+      "rapid stop→switch: B's POST waits for A's in-flight POST to drain", .timeLimit(.minutes(1)))
     func switchWaitsForInflightDrain() async throws {
       let session = MockURLSession()
       let reporter = makeReporter(session)
@@ -514,10 +515,14 @@ struct ListeningSessionTests {
 }
 
 /// Lets a test hold the first mock request in flight and release it on demand,
-/// to assert ordering across concurrent reporter transitions.
+/// to assert ordering across concurrent reporter transitions. Uses a
+/// continuation rather than a poll loop, so it neither busy-waits nor releases
+/// early when the holding task is cancelled (the test drives release explicitly;
+/// the `.timeLimit` trait on the test is the escape hatch if release is missed).
 private actor TestGate {
   private var claimed = false
   private var released = false
+  private var continuation: CheckedContinuation<Void, Never>?
 
   func claimFirst() -> Bool {
     if claimed { return false }
@@ -526,8 +531,13 @@ private actor TestGate {
   }
 
   func waitUntilReleased() async {
-    while !released { try? await Task.sleep(nanoseconds: 5_000_000) }
+    if released { return }
+    await withCheckedContinuation { continuation = $0 }
   }
 
-  func release() { released = true }
+  func release() {
+    released = true
+    continuation?.resume()
+    continuation = nil
+  }
 }

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -268,4 +268,127 @@ struct ListeningSessionTests {
           == "http://localhost:8080/v1/listeningSessions/end")
     }
   }
+
+  @Suite("State-driven session lifecycle")
+  @MainActor
+  struct StateDrivenLifecycle {
+    /// Polls until `condition` is true or the timeout elapses. The reporter
+    /// drives POSTs from detached Tasks, so assertions must wait for them.
+    func waitUntil(
+      _ condition: @MainActor @escaping () -> Bool, timeout: TimeInterval = 2.0
+    ) async {
+      let deadline = Date().addingTimeInterval(timeout)
+      while Date() < deadline {
+        if condition() { return }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+      }
+    }
+
+    private func makeReporter(_ session: MockURLSession) -> ListeningSessionReporter {
+      ListeningSessionReporter(
+        authProvider: MockAuthProvider(currentToken: "valid.token"), urlSession: session)
+    }
+
+    @Test("`.playing` starts a session with a POST to /listeningSessions")
+    func playingStartsSession() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60  // keep the heartbeat from repeating mid-test
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+
+      await waitUntil { session.requestCallCount >= 1 }
+      #expect(session.requestCallCount == 1)
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions")
+    }
+
+    @Test("`.loading` does not create a session")
+    func loadingDoesNothing() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+
+      reporter.handleStateChange(.loading(0.5))
+
+      try? await Task.sleep(nanoseconds: 150_000_000)
+      #expect(session.requestCallCount == 0)
+    }
+
+    @Test("`.idle` after playing ends the session with a POST to /listeningSessions/end")
+    func idleAfterPlayingEndsSession() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      await waitUntil { session.requestCallCount >= 1 }
+
+      reporter.handleStateChange(.idle)
+      await waitUntil {
+        session.lastRequest?.url?.absoluteString.hasSuffix("/listeningSessions/end") == true
+      }
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions/end")
+    }
+
+    @Test("`.idle` with no active session does not send a bogus /end")
+    func idleWithoutSessionSendsNothing() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+
+      reporter.handleStateChange(.idle)
+
+      try? await Task.sleep(nanoseconds: 150_000_000)
+      #expect(session.requestCallCount == 0)
+    }
+
+    @Test("`.paused` after playing ends the session")
+    func pausedAfterPlayingEndsSession() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      await waitUntil { session.requestCallCount >= 1 }
+
+      reporter.handleStateChange(.paused(.mockWith(stationId: "station-1")))
+      await waitUntil {
+        session.lastRequest?.url?.absoluteString.hasSuffix("/listeningSessions/end") == true
+      }
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions/end")
+    }
+
+    @Test("heartbeat keeps POSTing /listeningSessions while playing")
+    func heartbeatRepeatsWhilePlaying() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 0.05
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+
+      await waitUntil { session.requestCallCount >= 3 }
+      #expect(session.requestCallCount >= 3)
+
+      reporter.handleStateChange(.idle)  // stop the heartbeat so the test settles
+    }
+
+    @Test("repeated `.playing` for the same station does not start a second heartbeat")
+    func duplicatePlayingDoesNotDoubleStart() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      await waitUntil { session.requestCallCount >= 1 }
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      try? await Task.sleep(nanoseconds: 150_000_000)
+
+      #expect(session.requestCallCount == 1)
+    }
+  }
 }

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -362,6 +362,44 @@ struct ListeningSessionTests {
           == "https://admin-api.playola.fm/v1/listeningSessions/end")
     }
 
+    @Test("`.error` after playing ends the session")
+    func errorAfterPlayingEndsSession() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      await waitUntil { session.requestCallCount >= 1 }
+
+      reporter.handleStateChange(.error(.networkError("boom")))
+      await waitUntil {
+        session.lastRequest?.url?.absoluteString.hasSuffix("/listeningSessions/end") == true
+      }
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions/end")
+    }
+
+    @Test("a failed first POST does not produce a bogus /end on stop")
+    func failedFirstPostDoesNotEnd() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+      // First report fails, so no session is ever created server-side.
+      session.addResponse(
+        statusCode: 500,
+        url: URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!)
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-1")))
+      await waitUntil { session.requestCallCount >= 1 }  // the failed report happened
+
+      reporter.handleStateChange(.idle)
+      try? await Task.sleep(nanoseconds: 200_000_000)  // give the end task time to (not) fire
+
+      #expect(session.requestedURLs.allSatisfy { !$0.absoluteString.hasSuffix("/end") })
+      #expect(reporter.remoteSessionStarted == false)
+    }
+
     @Test("heartbeat keeps POSTing /listeningSessions while playing")
     func heartbeatRepeatsWhilePlaying() async throws {
       let session = MockURLSession()

--- a/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
+++ b/Tests/PlayolaPlayerTests/ListeningSessionTests.swift
@@ -390,5 +390,55 @@ struct ListeningSessionTests {
 
       #expect(session.requestCallCount == 1)
     }
+
+    @Test("switching stations keeps one session — reports the new station, never /end")
+    func switchingStationsDoesNotEnd() async throws {
+      let session = MockURLSession()
+      let reporter = makeReporter(session)
+      reporter.heartbeatInterval = 60
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-A")))
+      await waitUntil { session.requestCallCount >= 1 }
+
+      reporter.handleStateChange(.playing(.mockWith(stationId: "station-B")))
+      await waitUntil { session.requestCallCount >= 2 }
+
+      // A station switch is one continuous per-device session: it must report
+      // the new station and must NOT send /end.
+      #expect(session.requestedURLs.allSatisfy { !$0.absoluteString.hasSuffix("/end") })
+      #expect(
+        session.lastRequest?.url?.absoluteString
+          == "https://admin-api.playola.fm/v1/listeningSessions")
+    }
+
+    @Test("observes player $state: initial .idle is ignored, .playing starts, .idle ends")
+    func observesPlayerStateLifecycle() async throws {
+      let player = PlayolaStationPlayer()
+      let session = MockURLSession()
+      let reporter = ListeningSessionReporter(
+        stationPlayer: player,
+        authProvider: MockAuthProvider(currentToken: "valid.token"),
+        urlSession: session)
+      reporter.heartbeatInterval = 60
+
+      // The reporter subscribes to `$state`, whose current value is `.idle`.
+      // That initial emission must NOT send a bogus /end.
+      try? await Task.sleep(nanoseconds: 100_000_000)
+      #expect(session.requestCallCount == 0)
+
+      player.setStateForTesting(.playing(.mockWith(stationId: "s1")), stationId: "s1")
+      await waitUntil { session.requestCallCount >= 1 }
+      #expect(
+        session.lastRequest?.url?.absoluteString.hasSuffix("/v1/listeningSessions") == true)
+
+      player.setStateForTesting(.idle, stationId: nil)
+      await waitUntil {
+        session.lastRequest?.url?.absoluteString.hasSuffix("/listeningSessions/end") == true
+      }
+      #expect(
+        session.lastRequest?.url?.absoluteString.hasSuffix("/v1/listeningSessions/end") == true)
+      // Keeps `reporter` alive through the awaits and confirms the session cleared.
+      #expect(reporter.currentSessionStationId == nil)
+    }
   }
 }

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
@@ -12,6 +12,9 @@ final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
   var responses: [(Data, URLResponse)] = []
   var requestCallCount = 0
   var lastRequest: URLRequest?
+  /// Every requested URL in order, so tests can assert which endpoints were hit
+  /// (e.g. that no `/end` was ever sent), not just the most recent one.
+  var requestedURLs: [URL] = []
 
   /// When set, every call throws this error (simulating a transport-level
   /// failure such as a `URLError`) instead of returning a response.
@@ -20,6 +23,7 @@ final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
   func data(for request: URLRequest) async throws -> (Data, URLResponse) {
     requestCallCount += 1
     lastRequest = request
+    if let url = request.url { requestedURLs.append(url) }
 
     if let errorToThrow {
       throw errorToThrow

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockUrlSession.swift
@@ -20,10 +20,17 @@ final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
   /// failure such as a `URLError`) instead of returning a response.
   var errorToThrow: Error?
 
+  /// Optional async hook invoked at the start of each `data(for:)`, before the
+  /// response is returned. Lets a test suspend a specific request to assert
+  /// ordering across concurrent callers (e.g. hold station A's POST in flight).
+  var beforeResponse: (@Sendable (URLRequest) async -> Void)?
+
   func data(for request: URLRequest) async throws -> (Data, URLResponse) {
     requestCallCount += 1
     lastRequest = request
     if let url = request.url { requestedURLs.append(url) }
+
+    if let beforeResponse { await beforeResponse(request) }
 
     if let errorToThrow {
       throw errorToThrow


### PR DESCRIPTION
The listening-session heartbeat ran on a foreground RunLoop `Timer` and the session lifecycle was driven by `stationId` (set during `.loading`, cleared by `stop()`), so on backgrounding the host's `stop()` fired `/listeningSessions/end` while `AVAudioEngine` kept playing pre-scheduled audio and the Timer froze with the suspended process — undercounting recorded listening time. This replaces the Timer with a background-safe, playback-state-driven `Task` that observes `$state`: it starts reporting only on a real `.playing`, ends only on a genuine `.paused`/`.idle`/`.error`, ignores `.loading`, and serializes all reports and `/end`s through one chain so a rapid stop/station-switch can't reorder POSTs. The example host now declares `UIBackgroundModes=audio` and the README documents the background contract (declare the audio mode, keep `.playback` active, never `stop()` on backgrounding). Adds 9 reporter tests (state lifecycle, station switch, real `$state` subscription, gated in-flight ordering); all 114 tests pass and SwiftLint is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled background audio playback support so listening-session updates can continue while the app is backgrounded.
  * Made listening-session reporting state-driven, improving continuity of heartbeats and handling of station switching.

* **Bug Fixes**
  * Prevented duplicate, missing, or out-of-order start/end requests during rapid state and station changes.
  * Avoided sending an end request if the initial session start was never successfully created.

* **Documentation**
  * Added instructions for background playback and “listening heartbeat” reporting requirements.
  * Clarified stop behavior: stop ends the listening session; backgrounding does not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->