### PR TITLE
fix(cache): make pruneCache honor excludeFilepaths (Stage 0 of AirPlay-2 activation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,8 +641,9 @@ let localURL = downloadManager.localURL(for: audioURL)
 // Clear entire cache
 try downloadManager.clearCache()
 
-// Prune cache with size limit
-try downloadManager.pruneCache(maxSize: 100 * 1024 * 1024, excludeFilepaths: [])
+// Prune cache with size limit (excluded files are never deleted, but still
+// count toward the total when deciding how much to prune)
+try await downloadManager.pruneCache(maxSize: 100 * 1024 * 1024, excludeFilepaths: [])
 
 // Check available disk space
 if let availableSpace = downloadManager.availableDiskSpace() {
@@ -1151,7 +1152,7 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
     
     // Cache management
     public func clearCache() throws
-    public func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws
+    public func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) async throws
     public func currentCacheSize() -> Int64
     public func availableDiskSpace() -> Int64?
 }

--- a/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
@@ -110,9 +110,10 @@ public protocol FileDownloadManaging {
   /// Prunes the cache to stay under the specified size limit
   /// - Parameters:
   ///   - maxSize: Maximum size in bytes for the cache (nil uses default)
-  ///   - excludeFilepaths: Paths to exclude from pruning
+  ///   - excludeFilepaths: Paths to exclude from pruning. Excluded files are never deleted, but
+  ///     their sizes still count toward the total when deciding how much to prune.
   /// - Throws: FileDownloadError if pruning fails
-  func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws
+  func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) async throws
 
   /// Returns the current size of the cache in bytes
   /// - Returns: The size in bytes
@@ -144,9 +145,14 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   /// File manager for cache operations
   private let fileManager = FileManager.default
 
+  /// Overrides the on-disk cache directory. Used only by tests that need an isolated,
+  /// disposable cache directory instead of the real per-platform location.
+  private let cacheDirectoryOverride: URL?
+
   #if os(iOS) || os(tvOS)
     /// Cache directory URL
     private var cacheDirectoryURL: URL {
+      if let cacheDirectoryOverride { return cacheDirectoryOverride }
       let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
       return documentsPath.appendingPathComponent(Self.subfolderName)
     }
@@ -155,6 +161,7 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   #if os(macOS)
     /// Cache directory URL
     private var cacheDirectoryURL: URL {
+      if let cacheDirectoryOverride { return cacheDirectoryOverride }
       let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
         .first!
       let bundleID = Bundle.main.bundleIdentifier ?? "fm.playola.PlayolaPlayer"
@@ -163,6 +170,13 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   #endif
 
   public init() {
+    self.cacheDirectoryOverride = nil
+    createCacheDirectoryIfNeeded()
+  }
+
+  /// Test-only initializer that isolates cache operations to a caller-supplied directory.
+  init(cacheDirectoryOverride: URL) {
+    self.cacheDirectoryOverride = cacheDirectoryOverride
     createCacheDirectoryIfNeeded()
   }
 
@@ -285,9 +299,11 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   }
 
   public func pruneCache() async {
-    await Task.detached(priority: .utility) {
-      await self.pruneCacheInternal()
-    }.value
+    do {
+      try await pruneCacheInternal()
+    } catch {
+      logger.error("Failed to prune cache: \(error)")
+    }
   }
 
   // MARK: - Cache Management
@@ -302,9 +318,10 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
     return cacheDirectoryURL.appendingPathComponent(fileName)
   }
 
-  private func pruneCacheInternal(maxSize: Int64 = FileDownloadManagerAsync.MAX_AUDIO_FOLDER_SIZE)
-    async
-  {
+  private func pruneCacheInternal(
+    maxSize: Int64 = FileDownloadManagerAsync.MAX_AUDIO_FOLDER_SIZE,
+    excludedPaths: Set<String> = []
+  ) async throws {
     do {
       let contents = try fileManager.contentsOfDirectory(
         at: cacheDirectoryURL, includingPropertiesForKeys: [.fileSizeKey, .creationDateKey],
@@ -317,7 +334,9 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
         let attributes = try fileURL.resourceValues(forKeys: [.fileSizeKey, .creationDateKey])
         if let size = attributes.fileSize, let date = attributes.creationDate {
           totalSize += Int64(size)
-          fileInfos.append(FileInfo(url: fileURL, size: Int64(size), date: date))
+          if !excludedPaths.contains(Self.normalizedPath(for: fileURL)) {
+            fileInfos.append(FileInfo(url: fileURL, size: Int64(size), date: date))
+          }
         }
       }
 
@@ -335,8 +354,14 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
         }
       }
     } catch {
-      logger.error("Failed to prune cache: \(error)")
+      throw FileDownloadError.cachePruneFailed(error.localizedDescription)
     }
+  }
+
+  /// Normalizes a file URL's path so exclusion comparisons aren't defeated by symlink or
+  /// standardization differences (e.g. `/private/var` vs `/var`, trailing components).
+  private static func normalizedPath(for url: URL) -> String {
+    url.resolvingSymlinksInPath().standardizedFileURL.path
   }
 
   // MARK: - FileDownloadManaging Protocol Implementation
@@ -505,12 +530,11 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   }
 
   /// Prunes the cache to stay under the specified size limit
-  public func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws {
-    // For now, we'll use the internal prune method synchronously
-    // Note: This could block but maintains protocol compatibility
-    Task {
-      await pruneCacheInternal(maxSize: maxSize ?? Self.MAX_AUDIO_FOLDER_SIZE)
-    }
+  public func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) async throws {
+    let excludedPaths = Set(
+      excludeFilepaths.map { Self.normalizedPath(for: URL(fileURLWithPath: $0)) })
+    try await pruneCacheInternal(
+      maxSize: maxSize ?? Self.MAX_AUDIO_FOLDER_SIZE, excludedPaths: excludedPaths)
   }
 
   /// Returns the current size of the cache in bytes

--- a/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
@@ -169,6 +169,8 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
     }
   #endif
 
+  /// Creates a download manager backed by the default per-platform cache directory,
+  /// creating that directory if it doesn't already exist.
   public init() {
     self.cacheDirectoryOverride = nil
     createCacheDirectoryIfNeeded()

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -922,7 +922,7 @@ final public class PlayolaStationPlayer: ObservableObject {
         // prune (active files excluded so an in-use spin can't be evicted).
         if let controller = sampleBufferController {
           do {
-            try fileDownloadManager.pruneCache(
+            try await fileDownloadManager.pruneCache(
               maxSize: nil, excludeFilepaths: controller.activeLocalFilePaths)
           } catch {
             Task {
@@ -1206,7 +1206,7 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
           .compactMap { $0.localUrl?.path }
 
         // Use the new pruning method with proper error handling
-        try self.fileDownloadManager.pruneCache(maxSize: nil, excludeFilepaths: activePaths)
+        try await self.fileDownloadManager.pruneCache(maxSize: nil, excludeFilepaths: activePaths)
       } catch {
         Task {
           await errorReporter.reportError(

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -1199,14 +1199,15 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
     schedulingTask?.cancel()
     schedulingTask = Task { [generation = playGeneration] in
       do {
-        await self.scheduleUpcomingSpins(generation: generation)
-
-        // Get a list of active file paths to exclude from pruning
+        // Prune before entering the scheduling loop (which doesn't return while
+        // playback is live), so the cache is bounded at every spin start rather
+        // than only when a superseding play()/stop() cancels this task.
         let activePaths = self._spinPlayers
           .compactMap { $0.localUrl?.path }
 
-        // Use the new pruning method with proper error handling
         try await self.fileDownloadManager.pruneCache(maxSize: nil, excludeFilepaths: activePaths)
+
+        await self.scheduleUpcomingSpins(generation: generation)
       } catch {
         Task {
           await errorReporter.reportError(

--- a/Tests/PlayolaPlayerTests/FileDownloadManagerPruneCacheTests.swift
+++ b/Tests/PlayolaPlayerTests/FileDownloadManagerPruneCacheTests.swift
@@ -1,0 +1,112 @@
+//  FileDownloadManagerPruneCacheTests.swift
+//  PlayolaPlayer
+//
+// Covers pruneCache(maxSize:excludeFilepaths:) — active-file exclusions must survive pruning,
+// their size still counts toward pressure accounting, path-form differences can't defeat an
+// exclusion, and deletion failures must propagate instead of being silently swallowed.
+
+import Foundation
+import Testing
+
+@testable import PlayolaPlayer
+
+@MainActor
+struct FileDownloadManagerPruneCacheTests {
+  private func makeManager() throws -> (manager: FileDownloadManagerAsync, dir: URL) {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("FileDownloadManagerPruneCacheTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return (FileDownloadManagerAsync(cacheDirectoryOverride: dir), dir)
+  }
+
+  @discardableResult
+  private func writeFile(
+    named name: String, sizeBytes: Int, createdAt date: Date, in dir: URL
+  ) throws -> URL {
+    let url = dir.appendingPathComponent(name)
+    try Data(repeating: 0x1, count: sizeBytes).write(to: url)
+    try FileManager.default.setAttributes([.creationDate: date], ofItemAtPath: url.path)
+    return url
+  }
+
+  @Test("excluded active file survives prune under pressure")
+  func excludedActiveFileSurvivesPruneUnderPressure() async throws {
+    let (manager, dir) = try makeManager()
+    let now = Date()
+    let excludedURL = try writeFile(
+      named: "excluded-oldest.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-300),
+      in: dir)
+    try writeFile(
+      named: "middle.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-200), in: dir)
+    try writeFile(
+      named: "newest.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-100), in: dir)
+
+    try await manager.pruneCache(maxSize: 80, excludeFilepaths: [excludedURL.path])
+
+    let remaining = Set(try FileManager.default.contentsOfDirectory(atPath: dir.path))
+    #expect(remaining.contains("excluded-oldest.mp3"))
+    #expect(!remaining.contains("middle.mp3"))
+    #expect(remaining.contains("newest.mp3"))
+  }
+
+  @Test("non-excluded files are deleted oldest-first and the size target is met")
+  func nonExcludedFilesDeletedOldestFirstAndSizeTargetMet() async throws {
+    let (manager, dir) = try makeManager()
+    let now = Date()
+    try writeFile(
+      named: "oldest.mp3", sizeBytes: 60, createdAt: now.addingTimeInterval(-200), in: dir)
+    try writeFile(
+      named: "newest.mp3", sizeBytes: 60, createdAt: now.addingTimeInterval(-100), in: dir)
+
+    try await manager.pruneCache(maxSize: 60, excludeFilepaths: [])
+
+    let remaining = Set(try FileManager.default.contentsOfDirectory(atPath: dir.path))
+    #expect(!remaining.contains("oldest.mp3"))
+    #expect(remaining.contains("newest.mp3"))
+
+    let finalSize = try remaining.reduce(Int64(0)) { total, name in
+      let attrs = try FileManager.default.attributesOfItem(
+        atPath: dir.appendingPathComponent(name).path)
+      return total + Int64(attrs[.size] as? Int ?? 0)
+    }
+    #expect(finalSize <= 60)
+  }
+
+  @Test("exclusion survives non-standardized path form differences")
+  func exclusionSurvivesPathFormDifferences() async throws {
+    let (manager, dir) = try makeManager()
+    let now = Date()
+    let excludedURL = try writeFile(
+      named: "excluded.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-300), in: dir)
+    try writeFile(
+      named: "newer.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-100), in: dir)
+
+    let nonStandardizedPath = dir.path + "/./excluded.mp3"
+    #expect(nonStandardizedPath != excludedURL.path)
+
+    try await manager.pruneCache(maxSize: 40, excludeFilepaths: [nonStandardizedPath])
+
+    let remaining = Set(try FileManager.default.contentsOfDirectory(atPath: dir.path))
+    #expect(remaining.contains("excluded.mp3"))
+    #expect(!remaining.contains("newer.mp3"))
+  }
+
+  @Test("a deletion failure propagates to the caller instead of being swallowed")
+  func deletionFailurePropagatesToCaller() async throws {
+    let (manager, dir) = try makeManager()
+    let now = Date()
+    try writeFile(named: "a.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-200), in: dir)
+    try writeFile(named: "b.mp3", sizeBytes: 40, createdAt: now.addingTimeInterval(-100), in: dir)
+
+    // Removing write permission on the containing directory makes removeItem(at:) fail even
+    // though the files themselves remain readable.
+    try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+    defer {
+      try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
+    }
+
+    await #expect(throws: (any Error).self) {
+      try await manager.pruneCache(maxSize: 40, excludeFilepaths: [])
+    }
+  }
+}

--- a/Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swift
+++ b/Tests/PlayolaPlayerTests/Test Utilities/MockFileDownloadManager.swift
@@ -47,7 +47,10 @@ class MockFileDownloadManager: FileDownloadManaging {
   nonisolated func clearCache() throws {
   }
 
-  nonisolated func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) throws {
+  private(set) var pruneCacheInvocations: [(maxSize: Int64?, excludeFilepaths: [String])] = []
+
+  func pruneCache(maxSize: Int64?, excludeFilepaths: [String]) async throws {
+    pruneCacheInvocations.append((maxSize, excludeFilepaths))
   }
 
   nonisolated func currentCacheSize() -> Int64 {


### PR DESCRIPTION
## Why

`pruneCache(maxSize:excludeFilepaths:)` ignored its exclusion list entirely — it fire-and-forgot `pruneCacheInternal(maxSize:)` inside a `Task {}`, so:

- **Active files could be evicted under cache pressure.** The sample-buffer poll loop passes `activeLocalFilePaths` and the legacy path passes `_spinPlayers` local URLs; both were silently ignored. On a long session under pressure, a file actively being decoded could be deleted → dropout/corruption. This is the Stage 0 activation blocker for the AirPlay-2 sample-buffer rollout.
- **The `throws` contract was fake.** Errors were swallowed inside the un-awaited Task; callers' catch blocks could never fire.
- **Completion was racy.** Callers believed pruning had finished when it hadn't started.

## What

- `FileDownloadManaging.pruneCache(maxSize:excludeFilepaths:)` is now `async throws`; both SDK call sites were already in async contexts with catch blocks reporting to `PlayolaErrorReporter`, so errors now actually propagate.
- Exclusions are honored in the prune loop: excluded files are never deleted but **still count toward the size total**, so pressure accounting stays truthful. Deletion remains oldest-first among non-excluded files.
- Exclusion comparison normalizes both sides (`resolvingSymlinksInPath` + `standardizedFileURL`) so `/private/var` vs `/var` path forms can't defeat it.
- The no-arg `pruneCache()` keeps its existing log-and-continue contract.
- Internal `init(cacheDirectoryOverride:)` seam (not public) so tests run against an isolated temp directory.

## Tests

Four new tests in `FileDownloadManagerPruneCacheTests`: exclusion survives pressure, oldest-first deletion still meets the size target, path-form normalization, and deletion failures propagate to the caller. Full suite green (112 + 66 tests), `swiftlint --strict` clean.

Codex adversarial review ran on this diff: no findings in the changed code (its two flags were pre-existing PR #106 paths; the claimed macOS test crash does not reproduce — suite passes on macOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cache cleanup now preserves files currently in use, preventing active downloads or playback content from being removed.
  - File exclusions are handled consistently even when paths use different formats or symbolic links.
  - Cache pruning failures are now reported reliably instead of being silently logged.
  - Cache size limits and oldest-first cleanup behavior are applied more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->