### PR TITLE
docs: scope 0.21.0-beta.2 honestly + document render backend host contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@ flipping the backend on is a separate, server-flagged app-side step.
   memory over a long session). **HomePod and Sonos are expected-compatible but
   unverified** — they speak the same AirPlay-2 long-form protocol, but no
   hardware pass has been run against them yet.
-- **Fixed-route only.** Output-latency compensation is read at `play()`. A
-  device that switches routes mid-session (e.g. local speaker → AirPlay,
-  ~18 ms → ~2000 ms) recovers playback but is mis-compensated by the latency
-  delta until the next `play()`. Live route-switch re-sync (and with it any
-  broader multi-room simultaneity claim) is deferred to `0.21.0-beta.3`.
+- **Fixed-route only.** Output-latency compensation is read once per `play()`,
+  when the playback pipeline starts. A device that switches routes mid-session
+  (e.g. local speaker → AirPlay, ~18 ms → ~2000 ms) recovers playback but is
+  mis-compensated by the latency delta until the next `play()`. Live
+  route-switch re-sync (and with it any broader multi-room simultaneity claim)
+  is deferred to `0.21.0-beta.3`.
 
 ### Added
 
@@ -51,8 +52,8 @@ flipping the backend on is a separate, server-flagged app-side step.
   - Mid-file join, route-change recovery (pause → refill → resume, verified on
     hardware against real ~2s AirPlay latency), and host-fed output-latency
     compensation for cross-device simultaneity at play start
-    (`outputLatencyCompensation`, read at `play()` — see the fixed-route note
-    above) — the SDK still touches `AVAudioSession` **nowhere** (the
+    (`outputLatencyCompensation`, read once per `play()` at pipeline start —
+    see the fixed-route note above) — the SDK still touches `AVAudioSession` **nowhere** (the
     seam-invariant test now also covers the new files).
 - **`PlayolaRenderBackend`** public enum (`.legacyEngine` / `.sampleBuffer`)
   and **`isRenderBackendLocked`** for QA UIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,29 @@ minor version.
 Pre-release for the Phase 5 render path. The new backend is **dormant by
 default** — apps that don't opt in get the exact same runtime behavior as
 0.20.x. Merging/pinning this version does not change what listeners hear;
-flipping the backend on is a separate, server-flagged app-side step gated on
-the device QA matrix.
+flipping the backend on is a separate, server-flagged app-side step.
+
+**Verification status (what this beta does and does not claim):**
+
+- **Device-verified on Apple TV** (fixed-route AirPlay-2 long-form: routing,
+  latency-compensated start, gapless boundaries, interruption recovery, bounded
+  memory over a long session). **HomePod and Sonos are expected-compatible but
+  unverified** — they speak the same AirPlay-2 long-form protocol, but no
+  hardware pass has been run against them yet.
+- **Fixed-route only.** Output-latency compensation is read at `play()`. A
+  device that switches routes mid-session (e.g. local speaker → AirPlay,
+  ~18 ms → ~2000 ms) recovers playback but is mis-compensated by the latency
+  delta until the next `play()`. Live route-switch re-sync (and with it any
+  broader multi-room simultaneity claim) is deferred to `0.21.0-beta.3`.
 
 ### Added
 
 - **Sample-buffer render backend (AirPlay-2 long-form), opt-in.** A second
   render path built on a custom software `TimelineMixer` feeding one
   `AVSampleBufferAudioRenderer` + `AVSampleBufferRenderSynchronizer`, so a
-  Playola station routes as AirPlay-2 **long-form** audio (HomePod / Apple TV /
-  Sonos multi-room) — something the `AVAudioEngine` path cannot do. Selected
+  Playola station routes as AirPlay-2 **long-form** audio (device-verified on
+  Apple TV; HomePod/Sonos expected-compatible, unverified — see the
+  verification status above) — something the `AVAudioEngine` path cannot do. Selected
   via the new `renderBackend:` parameter on `configure(...)` (or the
   `setRenderBackend(_:)` helper): defaults to `.legacyEngine` and locks at the
   first `play()`, so the proven engine path remains the byte-for-byte runtime
@@ -37,9 +50,10 @@ the device QA matrix.
     slow download can never stall the station.
   - Mid-file join, route-change recovery (pause → refill → resume, verified on
     hardware against real ~2s AirPlay latency), and host-fed output-latency
-    compensation for cross-device simultaneity
-    (`outputLatencyCompensation`) — the SDK still touches `AVAudioSession`
-    **nowhere** (the seam-invariant test now also covers the new files).
+    compensation for cross-device simultaneity at play start
+    (`outputLatencyCompensation`, read at `play()` — see the fixed-route note
+    above) — the SDK still touches `AVAudioSession` **nowhere** (the
+    seam-invariant test now also covers the new files).
 - **`PlayolaRenderBackend`** public enum (`.legacyEngine` / `.sampleBuffer`)
   and **`isRenderBackendLocked`** for QA UIs.
 - **`setRenderBackend(_:)`** for selecting the backend without calling
@@ -47,6 +61,17 @@ the device QA matrix.
   output-latency compensation on the `.sampleBuffer` backend.
 
 ### Fixed
+
+- **`pruneCache(maxSize:excludeFilepaths:)` now honors `excludeFilepaths`.**
+  The implementation previously ignored the exclusion list (and fire-and-forgot
+  the prune inside a `Task`, silently dropping errors), so under cache pressure
+  on a long session it could delete an audio file that was actively playing.
+  Both render backends pass their active files' paths and were affected. The
+  method is now `async throws`: exclusions are honored (with path
+  normalization, so `/private/var` vs `/var` forms can't defeat them), excluded
+  files still count toward the size total, and deletion errors propagate to the
+  caller. Callers implementing `FileDownloadManaging` must adopt the new
+  signature.
 
 - **Networks that block Playola over TCP now play via HTTP/3 (QUIC).** Some
   listeners sit behind routers / SSL-inspection middleboxes that interfere with

--- a/README.md
+++ b/README.md
@@ -609,6 +609,54 @@ PlayolaStationPlayer.shared.$state
     .store(in: &cancellables)
 ```
 
+### Render backends (AirPlay-2 long-form, opt-in)
+
+The SDK has two render backends behind one unchanged public contract
+(`State`, delegate, scheduling, downloads are identical on both):
+
+- **`.legacyEngine`** (default) — the proven `AVAudioEngine` graph. Runtime
+  behavior is byte-for-byte what shipped in 0.20.x.
+- **`.sampleBuffer`** — a custom software mixer feeding one
+  `AVSampleBufferAudioRenderer` + `AVSampleBufferRenderSynchronizer`, which
+  lets a station route as AirPlay-2 **long-form** audio (grouped/multi-room
+  targets) — something the engine path cannot do.
+
+Select the backend **before the first `play()`**; it locks for the life of the
+process once playback starts (`isRenderBackendLocked`):
+
+```swift
+let player = PlayolaStationPlayer.shared
+player.setRenderBackend(.sampleBuffer)   // or configure(renderBackend: .sampleBuffer)
+```
+
+**Verification status (0.21.0-beta.2):** device-verified on Apple TV
+(fixed-route long-form routing, gapless boundaries, interruption recovery,
+bounded memory). HomePod and Sonos speak the same protocol and are
+expected-compatible but have not had a hardware pass yet.
+
+#### Output-latency compensation (host contract)
+
+The SDK never reads `AVAudioSession` — including `outputLatency`. If you want
+multiple devices playing the same station to start in sync (local speaker
+≈ 18 ms vs AirPlay ≈ 2000 ms of presentation latency), the **host feeds the
+current route's latency** before each `play()`:
+
+```swift
+player.outputLatencyCompensation = AVAudioSession.sharedInstance().outputLatency
+try await player.play(stationId: stationId)
+```
+
+Contract and limitation (as of 0.21.0-beta.2):
+
+- The value is **read at `play()`** and baked into the render timeline. Update
+  it before each `play()` call.
+- **Fixed-route only.** If the route changes mid-session (e.g. the listener
+  moves playback from the phone speaker to an AirPlay target), playback
+  recovers automatically, but the compensation still reflects the old route —
+  the device is offset by the latency delta until the next `play()`. Live
+  route-switch re-sync is planned for `0.21.0-beta.3`.
+- On the `.legacyEngine` backend the value is unused.
+
 ### Migrating from 0.19.x to 0.20.0
 
 `0.20.0` makes the host the sole owner of the `AVAudioSession`. Earlier versions configured, activated, and self-handled interruptions for you. This is a breaking change; both steps are required.

--- a/README.md
+++ b/README.md
@@ -648,8 +648,10 @@ try await player.play(stationId: stationId)
 
 Contract and limitation (as of 0.21.0-beta.2):
 
-- The value is **read at `play()`** and baked into the render timeline. Update
-  it before each `play()` call.
+- The value is **read once per `play()`, when the playback pipeline starts**
+  (after the schedule loads, just before audio begins) and baked into the
+  render timeline. Set it before calling `play()`; changing it during playback
+  has no effect until the next `play()`.
 - **Fixed-route only.** If the route changes mid-session (e.g. the listener
   moves playback from the phone speaker to an AirPlay target), playback
   recovers automatically, but the compensation still reflects the old route —


### PR DESCRIPTION
Stage 3 of the AirPlay-2 rollout — the docs-only pass before tagging `0.21.0-beta.2`.

## What

- **CHANGELOG `0.21.0-beta.2`: verification-status block.** The Stage 1 device matrix ran on **Apple TV only** (Class A all green; B1 route-switch drift quantified at ≈1983 ms). The changelog now says exactly that: device-verified on Apple TV, HomePod/Sonos expected-compatible but unverified, fixed-route only — live route-switch re-sync deferred to `0.21.0-beta.3`. The previous copy implied a verified "HomePod / Apple TV / Sonos multi-room" claim.
- **CHANGELOG: add the `pruneCache(maxSize:excludeFilepaths:)` fix** (PR #107) to the beta.2 Fixed section — exclusions honored, `async throws`, path normalization.
- **README: new "Render backends (AirPlay-2 long-form, opt-in)" section** — backend selection + lock-at-first-play, verification status, and the `outputLatencyCompensation` host contract (host feeds it, SDK never reads `AVAudioSession`, read at `play()`, fixed-route limitation).

## Why

Tag discipline: `0.21.0-beta.2` must go on the QA-verified SHA plus docs-only commits. This is that docs-only commit. After merge, the tag lands on the merge commit.

Docs-only — no SDK code changes. All API claims verified against source (`configure(renderBackend:)`, `setRenderBackend(_:)`, `isRenderBackendLocked`, `outputLatencyCompensation` read only in `startSampleBufferPlayback`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in sample-buffer playback for AirPlay 2 long-form routing.
  - Added configurable output-latency compensation for supported playback routes.
  - Documented Apple TV verification and compatibility details for HomePod and Sonos.

- **Bug Fixes**
  - Improved cache pruning to honor excluded paths, enforce size limits, and report deletion errors.

- **Documentation**
  - Documented render-backend selection, limitations, latency behavior, and cache API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->